### PR TITLE
Make -ERR message field parser

### DIFF
--- a/src/Err.hs
+++ b/src/Err.hs
@@ -65,6 +65,6 @@ invalidSubjParser = string "Invalid Subject"
 permViolationParser :: Parser [Word8]
 permViolationParser = do
   pre <- string "Permissions Violation"
-  post <- asciisNotQuotes
+  post <- notQuotes
   return (pre ++ post)
 

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -93,15 +93,15 @@ ascii = Parser charP
 asciis :: Parser [W8.Word8]
 asciis = some ascii
 
-asciiNotQuote = Parser charP
+notQuote = Parser charP
   where
     charP bs
       | BS.empty == bs = Nothing
-      | W8.isAscii (BS.head bs) && BS.head bs /= W8._quotesingle = Just (BS.head bs, BS.tail bs)
+      | BS.head bs /= W8._quotesingle = Just (BS.head bs, BS.tail bs)
       | otherwise = Nothing
 
-asciisNotQuotes :: Parser [W8.Word8]
-asciisNotQuotes = some asciiNotQuote
+notQuotes :: Parser [W8.Word8]
+notQuotes = some notQuote
 
 integer :: Parser [W8.Word8]
 integer = stringWithChars [W8._0 .. W8._9]

--- a/test/ErrSpec.hs
+++ b/test/ErrSpec.hs
@@ -25,7 +25,11 @@ cases = [
   ("-ERR 'Maximum Payload Violation'\r\n", Err "Maximum Payload Violation" True),
   ("-ERR 'Invalid Subject'\r\n", Err "Invalid Subject" False),
   ("-ERR 'Permissions Violation For Subscription To FOO.'\r\n", Err "Permissions Violation For Subscription To FOO." False),
-  ("-ERR 'Permissions Violation For Publish To FOO.'\r\n", Err "Permissions Violation For Publish To FOO." False)
+  ("-ERR 'Permissions Violation For Subscription To >>>.*'\r\n", Err "Permissions Violation For Subscription To >>>.*" False),
+  ("-ERR 'Permissions Violation For Subscription To nonsense*'\r\n", Err "Permissions Violation For Subscription To nonsense*" False),
+  ("-ERR 'Permissions Violation For Publish To FOO.'\r\n", Err "Permissions Violation For Publish To FOO." False),
+  ("-ERR 'Permissions Violation For Publish To >>>.*'\r\n", Err "Permissions Violation For Publish To >>>.*" False),
+  ("-ERR 'Permissions Violation For Publish To nonsense*'\r\n", Err "Permissions Violation For Publish To nonsense*" False)
   ]
 
 spec :: Spec


### PR DESCRIPTION
-ERR parsers need to be looser for pub/sub permission violations
since the invalid subject is repeated back in the message field
which could be complete nonsense. A single quote is the only
known delimiter.

Closes #21 