### PR TITLE
Generate test cases

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -24,3 +24,9 @@ jobs:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v15
     - run: nix-shell --arg hls false --run "make test"
+  testlong:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v15
+    - run: nix-shell --arg hls false --run "make generated-unit-test"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v15
-    - run: nix-shell --arg hls false --run "make lint.out"
+    - run: nix-shell --arg hls false --run "hlint -git"
   test:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -3,23 +3,44 @@ coverage:
 	stack test --system-ghc --coverage
 	xdg-open `stack path --local-hpc-root`/index.html
 
-unit-test.out: $(wildcard src/*) $(wildcard test/Unit/*)
-	stack test  natskell:unit-test --system-ghc --ta '-j 16 --format=failed-examples'
-	touch unit-test.out
+generated-unit-test: /tmp/generated-unit-test.out
 
-fuzz-test.out: $(wildcard src/*) $(wildcard test/Fuzz/*)
+/tmp/generated-unit-test.out: $(wildcard src/*) $(wildcard test/Unit/*)
+	stack test  natskell:unit-test --system-ghc --ta '-j 16 --format=failed-examples --match=generated'
+	touch /tmp/generated-unit-test.out
+
+unit-test: /tmp/unit-test.out
+
+/tmp/unit-test.out: $(wildcard src/*) $(wildcard test/Unit/*)
+	stack test  natskell:unit-test --system-ghc --ta '-j 16 --format=failed-examples --skip=generated'
+	touch /tmp/unit-test.out
+
+fuzz-test: /tmp/fuzz-test.out
+
+/tmp/fuzz-test.out: $(wildcard src/*) $(wildcard test/Fuzz/*)
 	stack test  natskell:fuzz-test --system-ghc --ta '-j 16 --format=failed-examples'
-	touch fuzz-test.out
+	touch /tmp/fuzz-test.out
 
-system-test.out: $(wildcard src/*) $(wildcard test/System/*) 
+system-test: /tmp/system-test.out
+
+/tmp/system-test.out: $(wildcard src/*) $(wildcard test/System/*) 
 	stack test natskell:system-test --system-ghc --ta '-j 16 --format=failed-examples'
-	touch system-test.out
+	touch /tmp/system-test.out
 
-test: unit-test.out fuzz-test.out system-test.out
+test: /tmp/unit-test.out /tmp/fuzz-test.out /tmp/system-test.out
 
-lint.out: $(wildcard src/*) $(wildcard test/*) 
+lint: /tmp/lint.out
+
+/tmp/lint.out: $(wildcard src/*) $(wildcard test/*) 
 	hlint --git
-	touch lint.out
+	touch /tmp/lint.out
+
+PHONY clean:
+clean:
+	rm -f /tmp/unit-test.out
+	rm -f /tmp/system-test.out
+	rm -f /tmp/fuzz-test.out
+	rm -f /tmp/lint.out
 
 build-test:
 	stack test --fast --system-ghc --no-run-tests --ta '-j 16'

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ lint: /tmp/lint.out
 
 PHONY clean:
 clean:
+	rm -f /tmp/generated-unit-test.out
 	rm -f /tmp/unit-test.out
 	rm -f /tmp/system-test.out
 	rm -f /tmp/fuzz-test.out

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ coverage:
 generated-unit-test: /tmp/generated-unit-test.out
 
 /tmp/generated-unit-test.out: $(wildcard src/*) $(wildcard test/Unit/*)
-	stack test  natskell:unit-test --system-ghc --ta '-j 16 --format=failed-examples --match=generated'
+	stack test  natskell:unit-test --system-ghc --ta '-j 16 --format=failed-examples --match=generated --fail-fast'
 	touch /tmp/generated-unit-test.out
 
 unit-test: /tmp/unit-test.out

--- a/natskell.cabal
+++ b/natskell.cabal
@@ -25,7 +25,8 @@ library
         word8 >=0.1.3,
         aeson >=2.0.3.0,
         text >= 1.2.3.1,
-        network-simple >= 0.4.5
+        network-simple >= 0.4.5,
+        base64-bytestring >= 1.2.1.0
 
     build-tool-depends: hspec-discover:hspec-discover
 
@@ -70,6 +71,8 @@ test-suite unit-test
                        docker >=0.7.0.0,
                        network-simple >= 0.4.5,
                        QuickCheck >= 2.14.2,
+                       base64-bytestring >= 1.2.1.0,
+                       ascii >=1.2.3.0
     other-modules:
         Lib.Parser
         Parsers.Parsers
@@ -114,6 +117,7 @@ test-suite fuzz-test
                        docker >=0.7.0.0,
                        network-simple >= 0.4.5,
                        QuickCheck >= 2.14.2,
+                       base64-bytestring >= 1.2.1.0
     other-modules:
         Lib.Parser
         ParserSpec

--- a/natskell.cabal
+++ b/natskell.cabal
@@ -96,6 +96,7 @@ test-suite unit-test
         ConnectSpec
         SubSpec
         UnsubSpec
+        Fixtures
 
 test-suite fuzz-test
      default-language: Haskell2010

--- a/src/Lib/Parser.hs
+++ b/src/Lib/Parser.hs
@@ -104,6 +104,9 @@ not' c = Parser charP
 til :: W8.Word8 -> Parser [W8.Word8]
 til = some . not'
 
+find' :: W8.Word8 -> Parser [W8.Word8]
+find' c = (++) <$> til c <*> string (BS.pack [c])
+
 integer :: Parser [W8.Word8]
 integer = stringWithChars [W8._0 .. W8._9]
 
@@ -114,12 +117,19 @@ take' n p = (:) <$> p <*> take' (n -1) p
 tokenParser :: Parser [W8.Word8]
 tokenParser = alphaNumerics <|> string "*"
 
-subjectParser :: Parser [W8.Word8]
-subjectParser = do
+wireTapParser :: Parser [W8.Word8]
+wireTapParser = do
+  string ">"
+
+specificSubjectParser :: Parser [W8.Word8]
+specificSubjectParser = do
   head <- tokenParser
   rest <- ((++) <$> string "." <*> subjectParser) <|> (string ".>" <|> string "")
-
   return (head ++ rest)
+
+subjectParser :: Parser [W8.Word8]
+subjectParser = do
+  wireTapParser <|> specificSubjectParser
 
 toInt :: BS.ByteString -> Int
 toInt bs = read (C.unpack bs) :: Int

--- a/src/Parsers/Parsers.hs
+++ b/src/Parsers/Parsers.hs
@@ -7,10 +7,7 @@ import qualified Control.Monad.Fail   as Fail
 import           Data.Aeson
 import           Data.ByteString
 import qualified Data.ByteString.Lazy as BSL
-import qualified Data.Text            as T
-import qualified Data.Text.Encoding   as TE
 import           Data.Word8
-import           Debug.Trace
 import           Lib.Parser
 import           Types.Err
 import           Types.Info

--- a/src/Parsers/Parsers.hs
+++ b/src/Parsers/Parsers.hs
@@ -102,6 +102,10 @@ infoParser = do
   string "INFO"
   ss
   rest <- asciis
+  -- TODO: there might be one of these, but asciis will have consumed it.
+  -- A more generic JSON parser would be handy
+  -- string "\r\n"
+
   case eitherDecode . BSL.fromStrict $ pack rest of
     Right a -> return (ParsedInfo a)
     Left e  -> Fail.fail "decode failed"
@@ -118,7 +122,7 @@ msgWithReplyAndPayloadparser = do
   ss
   subj <- subjectParser
   ss
-  sid <- integer
+  sid <- alphaNumerics
   ss
   reply <- subjectParser
   ss
@@ -130,7 +134,7 @@ msgWithReplyAndPayloadparser = do
   return
     (ParsedMsg $ Msg
         (pack subj)
-        (toInt . pack $ sid)
+        (pack sid)
         (Just (pack reply))
         countInt
         (Just (pack payload))
@@ -142,7 +146,7 @@ msgWithPayloadparser = do
   ss
   subj <- subjectParser
   ss
-  sid <- integer
+  sid <- alphaNumerics
   ss
   count <- integer
   string "\r\n"
@@ -152,7 +156,7 @@ msgWithPayloadparser = do
   return
     (ParsedMsg $ Msg
         (pack subj)
-        (toInt . pack $ sid)
+        (pack sid)
         Nothing
         countInt
         (Just (pack payload))
@@ -164,7 +168,7 @@ msgWithReplyparser = do
   ss
   subj <- subjectParser
   ss
-  sid <- integer
+  sid <- alphaNumerics
   ss
   reply <- subjectParser
   ss
@@ -173,7 +177,7 @@ msgWithReplyparser = do
   return
     (ParsedMsg $ Msg
         (pack subj)
-        (toInt . pack $ sid)
+        (pack sid)
         (Just (pack reply))
         (toInt . pack $ count)
         Nothing
@@ -185,14 +189,14 @@ msgMinParser = do
   ss
   subj <- subjectParser
   ss
-  sid <- integer
+  sid <- alphaNumerics
   ss
   count <- integer
   string "\r\n"
   return
     (ParsedMsg $ Msg
         (pack subj)
-        (toInt . pack $ sid)
+        (pack sid)
         Nothing
         (toInt . pack $ count)
         Nothing

--- a/src/Transformers/Transformers.hs
+++ b/src/Transformers/Transformers.hs
@@ -47,8 +47,8 @@ instance Transformer Pub.Pub where
 instance Transformer Sub.Sub where
   transform d = do
     case Sub.queueGroup d of
-       Just a  -> packStr' (printf "SUB %s %s %s" subj a id)
-       Nothing -> packStr' (printf "SUB %s %s" subj id)
+       Just a  -> foldr BS.append "" ["SUB ", subj, " ", a, " ", id]
+       Nothing -> foldr BS.append "" ["SUB ", subj, " ", id]
     where
       subj = Sub.subject d
       qg = Sub.queueGroup d
@@ -57,8 +57,8 @@ instance Transformer Sub.Sub where
 instance Transformer Unsub.Unsub where
   transform d = do
     case mm of
-       Just a  -> packStr' (printf "UNSUB %s %u" id a)
-       Nothing -> packStr' (printf "UNSUB %s" id)
+       Just a  -> foldr BS.append "" ["UNSUB ", id, " ", packInt a]
+       Nothing -> foldr BS.append "" ["UNSUB ", id]
     where
       id = Unsub.sid d
       mm = Unsub.maxMsg d
@@ -74,3 +74,4 @@ lengthNothing = maybe 0 BS.length
 packStr' :: String -> BS.ByteString
 packStr' = encodeUtf8 . Text.pack
 
+packInt = packStr' . show

--- a/src/Types/Connect.hs
+++ b/src/Types/Connect.hs
@@ -5,7 +5,6 @@ module Types.Connect where
 import           Control.Monad
 import           Data.Aeson
 import qualified Data.ByteString        as BS
-import qualified Data.ByteString.Base64 as B64
 import qualified Data.Text              as T
 import qualified Data.Text.Encoding     as E
 import           GHC.Generics

--- a/src/Types/Connect.hs
+++ b/src/Types/Connect.hs
@@ -2,8 +2,12 @@
 
 module Types.Connect where
 
+import           Control.Monad
 import           Data.Aeson
-import           Data.Text
+import qualified Data.ByteString        as BS
+import qualified Data.ByteString.Base64 as B64
+import qualified Data.Text              as T
+import qualified Data.Text.Encoding     as E
 import           GHC.Generics
 
 data Connect = Connect
@@ -11,19 +15,32 @@ data Connect = Connect
     verbose      :: Bool,
     pedantic     :: Bool,
     tls_required :: Bool,
-    auth_token   :: Maybe Text,
-    user         :: Maybe Text,
-    pass         :: Maybe Text,
-    name         :: Maybe Text,
-    lang         :: Text,
+    auth_token   :: Maybe BS.ByteString,
+    user         :: Maybe BS.ByteString,
+    pass         :: Maybe BS.ByteString,
+    name         :: Maybe BS.ByteString,
+    lang         :: BS.ByteString,
     version      :: Int,
     protocol     :: Maybe Int,
     echo         :: Maybe Bool,
-    sig          :: Maybe Text,
-    jwt          :: Maybe Text
+    sig          :: Maybe BS.ByteString,
+    jwt          :: Maybe BS.ByteString
   }
   deriving (Eq, Show, Generic)
+
 instance ToJSON Connect where
   toJSON = genericToJSON defaultOptions
     {omitNothingFields = True}
 
+instance ToJSON BS.ByteString where
+  toJSON = toJSON . byteStringToText
+
+instance FromJSON BS.ByteString where
+  parseJSON (String x) = textToByteString x
+  parseJSON _          = mzero
+
+textToByteString :: MonadPlus m =>  T.Text -> m BS.ByteString
+textToByteString x = pure $ E.encodeUtf8 x
+
+byteStringToText :: BS.ByteString -> T.Text
+byteStringToText = E.decodeUtf8

--- a/src/Types/Connect.hs
+++ b/src/Types/Connect.hs
@@ -4,9 +4,9 @@ module Types.Connect where
 
 import           Control.Monad
 import           Data.Aeson
-import qualified Data.ByteString        as BS
-import qualified Data.Text              as T
-import qualified Data.Text.Encoding     as E
+import qualified Data.ByteString    as BS
+import qualified Data.Text          as T
+import qualified Data.Text.Encoding as E
 import           GHC.Generics
 
 data Connect = Connect
@@ -19,7 +19,7 @@ data Connect = Connect
     pass         :: Maybe BS.ByteString,
     name         :: Maybe BS.ByteString,
     lang         :: BS.ByteString,
-    version      :: Int,
+    version      :: BS.ByteString,
     protocol     :: Maybe Int,
     echo         :: Maybe Bool,
     sig          :: Maybe BS.ByteString,

--- a/src/Types/Info.hs
+++ b/src/Types/Info.hs
@@ -2,25 +2,42 @@
 
 module Types.Info where
 
+import           Control.Monad
 import           Data.Aeson
-import           Data.Text
+import qualified Data.ByteString        as BS
+import qualified Data.ByteString.Base64 as B64
+import qualified Data.Text              as T
+import qualified Data.Text.Encoding     as E
 import           GHC.Generics
 
 data Info = Info
-  { server_id     :: Text,
-    version       :: Text,
-    go            :: Text,
-    host          :: Text,
+  { server_id     :: BS.ByteString,
+    version       :: BS.ByteString,
+    go            :: BS.ByteString,
+    host          :: BS.ByteString,
     port          :: Int,
     max_payload   :: Int,
     proto         :: Int,
     client_id     :: Maybe Int,
     auth_required :: Maybe Bool,
     tls_required  :: Maybe Bool,
-    connect_urls  :: Maybe [String],
+    connect_urls  :: Maybe [BS.ByteString],
     ldm           :: Maybe Bool
   }
   deriving (Eq, Show, Generic)
 
 instance FromJSON Info
 instance ToJSON Info
+
+instance ToJSON BS.ByteString where
+  toJSON = toJSON . byteStringToText
+
+instance FromJSON BS.ByteString where
+  parseJSON (String x) = textToByteString x
+  parseJSON _          = mzero
+
+textToByteString :: MonadPlus m =>  T.Text -> m BS.ByteString
+textToByteString x = pure $ E.encodeUtf8 x
+
+byteStringToText :: BS.ByteString -> T.Text
+byteStringToText = E.decodeUtf8

--- a/src/Types/Info.hs
+++ b/src/Types/Info.hs
@@ -5,7 +5,6 @@ module Types.Info where
 import           Control.Monad
 import           Data.Aeson
 import qualified Data.ByteString        as BS
-import qualified Data.ByteString.Base64 as B64
 import qualified Data.Text              as T
 import qualified Data.Text.Encoding     as E
 import           GHC.Generics

--- a/src/Types/Msg.hs
+++ b/src/Types/Msg.hs
@@ -4,7 +4,7 @@ import           Data.ByteString
 
 data Msg = Msg
   { subject   :: ByteString,
-    sid       :: Int,
+    sid       :: ByteString,
     replyTo   :: Maybe ByteString,
     byteCount :: Int,
     payload   :: Maybe ByteString

--- a/src/Types/Pub.hs
+++ b/src/Types/Pub.hs
@@ -7,4 +7,5 @@ data Pub = Pub
     replyTo :: Maybe ByteString,
     payload :: Maybe ByteString
   }
+  deriving (Eq, Show)
 

--- a/src/Types/Sub.hs
+++ b/src/Types/Sub.hs
@@ -1,7 +1,9 @@
 module Types.Sub where
 
+import qualified Data.ByteString as BS
+
 data Sub = Sub
-  { subject    :: String,
-    queueGroup :: Maybe String,
-    sid        :: String
+  { subject    :: BS.ByteString,
+    queueGroup :: Maybe BS.ByteString,
+    sid        :: BS.ByteString
   }

--- a/src/Types/Sub.hs
+++ b/src/Types/Sub.hs
@@ -7,3 +7,4 @@ data Sub = Sub
     queueGroup :: Maybe BS.ByteString,
     sid        :: BS.ByteString
   }
+  deriving (Eq, Show)

--- a/src/Types/Unsub.hs
+++ b/src/Types/Unsub.hs
@@ -6,4 +6,4 @@ data Unsub = Unsub
   { sid    :: BS.ByteString,
     maxMsg :: Maybe Int
   }
-
+  deriving (Eq, Show)

--- a/src/Types/Unsub.hs
+++ b/src/Types/Unsub.hs
@@ -1,7 +1,9 @@
 module Types.Unsub where
 
+import qualified Data.ByteString as BS
+
 data Unsub = Unsub
-  { sid    :: String,
+  { sid    :: BS.ByteString,
     maxMsg :: Maybe Int
   }
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -67,7 +67,7 @@ packages:
 # compiler-check: newer-minor
 # system-ghc: true
 ghc-options:
-  '$everything': -haddock
+  '$everything': -haddock -fwarn-unused-imports
 nix:
   enable: true
   packages: [zlib.dev, zlib.out]

--- a/test/Fuzz/ParserSpec.hs
+++ b/test/Fuzz/ParserSpec.hs
@@ -1,16 +1,12 @@
 module ParserSpec (spec) where
 
-import           Control.Monad
 import qualified Data.ByteString       as BS
 import qualified Data.ByteString.Char8 as B
-import           Data.Char
-import qualified Data.Word8            as W8
 import           Data.Maybe
 import qualified Lib.Parser            as Parser
 import           Test.Hspec
 import           Test.Hspec.QuickCheck (modifyMaxSuccess)
 import           Test.QuickCheck
-import           Text.Printf
 
 spec :: Spec
 spec = do

--- a/test/System/ClientSpec.hs
+++ b/test/System/ClientSpec.hs
@@ -3,9 +3,8 @@ module ClientSpec (spec) where
 import           Client
 import           Control.Exception
 import           Control.Monad
-import qualified Docker.Client      as DC
+import qualified Docker.Client     as DC
 import           NatsWrappers
-import qualified Network.Simple.TCP as TCP
 import           Test.Hspec
 
 spec :: Spec

--- a/test/System/ClientSpec.hs
+++ b/test/System/ClientSpec.hs
@@ -18,9 +18,8 @@ versions :: [String]
 versions = ["latest", "2.9.8", "2.9.6"]
 
 sys = parallel $ do
-  describe "Client" $ do
-    describe "systest" $ do
-      forM_ versions $ \version ->
-        around (withNATSConnection version) $ do
-          it "connects successfully" $ \(_, host, port) -> do
-            connect host port 10
+  describe "client" $ do
+    forM_ versions $ \version ->
+      around (withNATSConnection version) $ do
+        it "connects successfully" $ \(_, host, port) -> do
+          connect host port 10

--- a/test/System/NatsWrappers.hs
+++ b/test/System/NatsWrappers.hs
@@ -5,12 +5,10 @@ module NatsWrappers where
 import           Control.Concurrent
 import           Control.Exception
 import qualified Data.Conduit.Binary as Con
-import qualified Data.Text
 import qualified Data.Text           as Text
 import qualified Docker.Client       as DC
 import qualified Docker.Client.Types as DCT
 import qualified Network.HTTP        as HTTP
-import qualified Network.Simple.TCP  as TCP
 
 second = 1000000
 

--- a/test/Unit/ConnectSpec.hs
+++ b/test/Unit/ConnectSpec.hs
@@ -2,17 +2,10 @@
 
 module ConnectSpec (spec) where
 
-import           Control.Concurrent
-import           Control.Exception
 import           Control.Monad
 import           Data.Aeson
 import qualified Data.ByteString           as BS
 import qualified Data.ByteString.Lazy      as LBS
-import           Data.Text                 (Text, pack)
-import           Data.Text.Encoding
-import qualified Docker.Client             as DC
-import           Fixtures
-import           Parsers.Parsers
 import           Test.Hspec
 import           Text.Printf
 import           Transformers.Transformers

--- a/test/Unit/ConnectSpec.hs
+++ b/test/Unit/ConnectSpec.hs
@@ -13,33 +13,35 @@ import           Types.Connect
 
 spec :: Spec
 spec = do
-  explicit
+  cases
 
-explicitCases :: [(BS.ByteString, Connect)]
+explicitCases :: [(Connect, BS.ByteString)]
 explicitCases = [
   (
-    "CONNECT {\"verbose\": false, \"pedantic\": false, \"tls_required\": false, \"lang\": \"Haskell\", \"version\": 1}",
-    Connect False False False Nothing Nothing Nothing Nothing "Haskell" 1 Nothing Nothing Nothing Nothing
+    Connect False False False Nothing Nothing Nothing Nothing "Haskell" 1 Nothing Nothing Nothing Nothing,
+    "CONNECT {\"verbose\": false, \"pedantic\": false, \"tls_required\": false, \"lang\": \"Haskell\", \"version\": 1}"
     ),
   (
-    "CONNECT {\"verbose\": true, \"pedantic\": true, \"tls_required\": true, \"auth_token\": \"token\", \"user\": \"user\", \"pass\": \"pass\", \"name\": \"name\", \"lang\": \"Haskell\", \"version\": 1, \"protocol\": 3, \"echo\": true, \"sig\": \"sig\", \"jwt\": \"jwt\"}",
-    Connect True True True (Just "token") (Just "user") (Just "pass") (Just "name") "Haskell" 1 (Just 3) (Just True) (Just "sig") (Just "jwt")
+    Connect True True True (Just "token") (Just "user") (Just "pass") (Just "name") "Haskell" 1 (Just 3) (Just True) (Just "sig") (Just "jwt"),
+    "CONNECT {\"verbose\": true, \"pedantic\": true, \"tls_required\": true, \"auth_token\": \"token\", \"user\": \"user\", \"pass\": \"pass\", \"name\": \"name\", \"lang\": \"Haskell\", \"version\": 1, \"protocol\": 3, \"echo\": true, \"sig\": \"sig\", \"jwt\": \"jwt\"}"
     )
   ]
 
-explicit = parallel $ do
-  describe "transformer" $ do
-    forM_ explicitCases $ \(want, input) -> do
-      it (printf "transforms %v successfully" (show input)) $ \f -> do
+cases = parallel $ do
+  describe "CONNECT transformer" $ do
+    forM_ explicitCases $ \(input, want) -> do
+      it (printf "correctly transforms %s" (show input)) $ do
+        let wantProto = BS.take 8 want
+        let wantJSONString = BS.drop 8 want
 
         let transformed = transform input
-
-        let gotProto = BS.take 7 transformed
+        let gotProto = BS.take 8 transformed
         let gotJSONString = BS.drop 8 transformed
 
-        let wantJSON = decode . LBS.fromStrict $ BS.drop 8 want :: Maybe Value
+        -- decode both to avoid field ordering issues
+        let wantJSON = decode . LBS.fromStrict $ wantJSONString :: Maybe Value
         let gotJSON = decode . LBS.fromStrict $ gotJSONString :: Maybe Value
 
-        gotProto `shouldBe` "CONNECT"
+        gotProto `shouldBe` wantProto
         gotJSON `shouldBe` wantJSON
 

--- a/test/Unit/ConnectSpec.hs
+++ b/test/Unit/ConnectSpec.hs
@@ -20,56 +20,15 @@ import           Types.Connect
 
 spec :: Spec
 spec = do
-  generated
   explicit
 
-
-generated = parallel $ do
-  describe "generated" $ do
-    describe "transformer" $ do
-      forM_ boolCases $ \verbosity ->
-        forM_ boolCases $ \pedanticity ->
-          forM_ boolCases $ \tlsRequirement ->
-            forM_ (maybeify jwtCases) $ \authTokenOptions ->
-              forM_ (maybeify userCases) $ \userOptions ->
-                forM_ (maybeify passCases) $ \passOptions ->
-                  forM_ (maybeify nameCases) $ \nameOptions ->
-                    forM_ (maybeify intCases) $ \protocolOptions ->
-                      forM_ (maybeify boolCases) $ \echoOptions ->
-                        forM_ (maybeify sigCases) $ \sigOptions ->
-                          forM_ (maybeify jwtCases) $ \jwtOptions -> do
-                            let d = Connect verbosity pedanticity tlsRequirement (fmap pack authTokenOptions) (fmap pack userOptions) (fmap pack passOptions) (fmap pack nameOptions) "Haskell" 1 (fmap fromIntegral protocolOptions) echoOptions (fmap pack sigOptions) (fmap pack jwtOptions)
-                            it (printf "transforms %v successfully" (show d)) $ \f -> do
-                              let transformed = transform d
-                              let proto = BS.take 7 transformed
-                              let json = BS.drop 8 transformed
-                              let expectedFields = BS.init $ foldr BS.append "" [
-                                    collapseMaybeStringField "auth_token" $ fmap pack authTokenOptions,
-                                    collapseMaybeBoolField "echo" echoOptions,
-                                    collapseMaybeStringField "jwt" $ fmap pack jwtOptions,
-                                    collapseMaybeStringField "lang" (Just "Haskell"),
-                                    collapseMaybeStringField "name" $ fmap pack nameOptions,
-                                    collapseMaybeStringField "pass" $ fmap pack passOptions,
-                                    collapseMaybeBoolField "pedantic" (Just pedanticity),
-                                    collapseMaybeIntField "protocol" $ fmap fromIntegral protocolOptions,
-                                    collapseMaybeStringField "sig" $ fmap pack sigOptions,
-                                    collapseMaybeBoolField "tls_required" (Just tlsRequirement),
-                                    collapseMaybeStringField "user" $ fmap pack userOptions,
-                                    collapseMaybeBoolField "verbose" (Just verbosity),
-                                    collapseMaybeIntField "version" (Just 1)
-                                    ]
-                              -- we don't really care about field order, nor do we want to ensure it in the test
-                              -- so we'll just decode the want and the got into a Haskell type and check they're equal
-                              let want = (decode . LBS.fromStrict $ foldr BS.append "" ["{", expectedFields, "}"]) :: Maybe Value
-                              let got = decode . LBS.fromStrict $ json :: Maybe Value
-                              proto `shouldBe` "CONNECT"
-                              got `shouldBe` want
 explicitCases :: [Connect]
 explicitCases = [
   Connect False False False Nothing Nothing Nothing Nothing "" 1 Nothing Nothing Nothing Nothing,
   Connect True True True (Just "token") (Just "user") (Just "pass") (Just "name") "Haskell" 1 (Just 3) (Just True) (Just "sig") (Just "jwt")
   ]
 
+-- TODO: we should make this JSON explicit rather than building fields
 explicit = parallel $ do
   describe "transformer" $ do
     forM_ explicitCases $ \input -> do
@@ -77,20 +36,20 @@ explicit = parallel $ do
         let transformed = transform input
         let proto = BS.take 7 transformed
         let json = BS.drop 8 transformed
-        let expectedFields = BS.init $ foldr BS.append "" [
-              collapseMaybeStringField "auth_token" $ auth_token input,
-              collapseMaybeBoolField "echo" $ echo input,
-              collapseMaybeStringField "jwt" $ jwt input,
-              collapseMaybeStringField "lang" (Just $ lang input),
-              collapseMaybeStringField "name" $ name input,
-              collapseMaybeStringField "pass" $ pass input,
-              collapseMaybeBoolField "pedantic" (Just $ pedantic input),
-              collapseMaybeIntField "protocol" $ protocol input,
-              collapseMaybeStringField "sig" $ sig input,
-              collapseMaybeBoolField "tls_required" (Just $ tls_required input),
-              collapseMaybeStringField "user" $ user input,
-              collapseMaybeBoolField "verbose" (Just $ verbose input),
-              collapseMaybeIntField "version" (Just $ version input)
+        let expectedFields = BS.init $ foldr BS.append "FIX ME " [
+--              collapseMaybeStringField "auth_token" $ auth_token input,
+--              collapseMaybeBoolField "echo" $ echo input,
+--              collapseMaybeStringField "jwt" $ jwt input,
+--              collapseMaybeStringField "lang" (Just $ lang input),
+--              collapseMaybeStringField "name" $ name input,
+--              collapseMaybeStringField "pass" $ pass input,
+--              collapseMaybeBoolField "pedantic" (Just $ pedantic input),
+--              collapseMaybeIntField "protocol" $ protocol input,
+--              collapseMaybeStringField "sig" $ sig input,
+--              collapseMaybeBoolField "tls_required" (Just $ tls_required input),
+--              collapseMaybeStringField "user" $ user input,
+--              collapseMaybeBoolField "verbose" (Just $ verbose input),
+--              collapseMaybeIntField "version" (Just $ version input)
               ]
         -- we don't really care about field order, nor do we want to ensure it in the test
         -- so we'll just decode the want and the got into a Haskell type and check they're equal

--- a/test/Unit/ConnectSpec.hs
+++ b/test/Unit/ConnectSpec.hs
@@ -11,6 +11,7 @@ import qualified Data.ByteString.Lazy      as LBS
 import           Data.Text                 (Text, pack)
 import           Data.Text.Encoding
 import qualified Docker.Client             as DC
+import           Fixtures
 import           Parsers.Parsers
 import           Test.Hspec
 import           Text.Printf
@@ -22,15 +23,6 @@ spec = do
   generated
   explicit
 
-boolCases = [True, False]
-maybeUserCases = [Just "samisagit", Just "sam@google.com", Nothing]
-maybePassCases = [Just "dsalkj09898(*)(UHJHI&*&*)(910", Nothing]
-maybeNameCases = [Just "natskell-client",  Nothing]
-maybeVersionCases = [Just "0.0.0", Just "v1.0.1", Just "13.0.0+123", Nothing]
-maybeSigCases = [Just "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQSflKxwRJSMeKKF2QT4fwpMeJf36POk6yJVadQssw5c", Nothing]
-maybeJwtCases = [Just "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c", Nothing]
-maybeIntCases = [Just 1, Nothing]
-maybeBoolCases = [Just True, Just False, Nothing]
 
 generated = parallel $ do
   describe "generated" $ do
@@ -38,31 +30,31 @@ generated = parallel $ do
       forM_ boolCases $ \verbosity ->
         forM_ boolCases $ \pedanticity ->
           forM_ boolCases $ \tlsRequirement ->
-            forM_ maybeJwtCases $ \authTokenOptions ->
-              forM_ maybeUserCases $ \userOptions ->
-                forM_ maybePassCases $ \passOptions ->
-                  forM_ maybeNameCases $ \nameOptions ->
-                    forM_ maybeIntCases $ \protocolOptions ->
-                      forM_ maybeBoolCases $ \echoOptions ->
-                        forM_ maybeSigCases $ \sigOptions ->
-                          forM_ maybeJwtCases $ \jwtOptions -> do
-                            let d = Connect verbosity pedanticity tlsRequirement authTokenOptions userOptions passOptions nameOptions "Haskell" 1 protocolOptions echoOptions sigOptions jwtOptions
+            forM_ (maybeify jwtCases) $ \authTokenOptions ->
+              forM_ (maybeify userCases) $ \userOptions ->
+                forM_ (maybeify passCases) $ \passOptions ->
+                  forM_ (maybeify nameCases) $ \nameOptions ->
+                    forM_ (maybeify intCases) $ \protocolOptions ->
+                      forM_ (maybeify boolCases) $ \echoOptions ->
+                        forM_ (maybeify sigCases) $ \sigOptions ->
+                          forM_ (maybeify jwtCases) $ \jwtOptions -> do
+                            let d = Connect verbosity pedanticity tlsRequirement (fmap pack authTokenOptions) (fmap pack userOptions) (fmap pack passOptions) (fmap pack nameOptions) "Haskell" 1 (fmap fromIntegral protocolOptions) echoOptions (fmap pack sigOptions) (fmap pack jwtOptions)
                             it (printf "transforms %v successfully" (show d)) $ \f -> do
                               let transformed = transform d
                               let proto = BS.take 7 transformed
                               let json = BS.drop 8 transformed
                               let expectedFields = BS.init $ foldr BS.append "" [
-                                    collapseMaybeStringField "auth_token" authTokenOptions,
+                                    collapseMaybeStringField "auth_token" $ fmap pack authTokenOptions,
                                     collapseMaybeBoolField "echo" echoOptions,
-                                    collapseMaybeStringField "jwt" jwtOptions,
+                                    collapseMaybeStringField "jwt" $ fmap pack jwtOptions,
                                     collapseMaybeStringField "lang" (Just "Haskell"),
-                                    collapseMaybeStringField "name" nameOptions,
-                                    collapseMaybeStringField "pass" passOptions,
+                                    collapseMaybeStringField "name" $ fmap pack nameOptions,
+                                    collapseMaybeStringField "pass" $ fmap pack passOptions,
                                     collapseMaybeBoolField "pedantic" (Just pedanticity),
-                                    collapseMaybeIntField "protocol" protocolOptions,
-                                    collapseMaybeStringField "sig" sigOptions,
+                                    collapseMaybeIntField "protocol" $ fmap fromIntegral protocolOptions,
+                                    collapseMaybeStringField "sig" $ fmap pack sigOptions,
                                     collapseMaybeBoolField "tls_required" (Just tlsRequirement),
-                                    collapseMaybeStringField "user" userOptions,
+                                    collapseMaybeStringField "user" $ fmap pack userOptions,
                                     collapseMaybeBoolField "verbose" (Just verbosity),
                                     collapseMaybeIntField "version" (Just 1)
                                     ]
@@ -106,20 +98,4 @@ explicit = parallel $ do
         let got = decode . LBS.fromStrict $ json :: Maybe Value
         proto `shouldBe` "CONNECT"
         got `shouldBe` want
-
-collapseMaybeStringField :: BS.ByteString -> Maybe Text -> BS.ByteString
-collapseMaybeStringField f v  = case v of
-  Nothing -> ""
-  Just a  -> foldr BS.append "" ["\"", f, "\":", "\"", encodeUtf8 a, "\","]
-
-collapseMaybeBoolField :: BS.ByteString -> Maybe Bool -> BS.ByteString
-collapseMaybeBoolField f v  = case v of
-  Nothing    -> ""
-  Just True  -> foldr BS.append "" ["\"", f, "\":", "true,"]
-  Just False -> foldr BS.append "" ["\"", f, "\":", "false,"]
-
-collapseMaybeIntField :: BS.ByteString -> Maybe Int -> BS.ByteString
-collapseMaybeIntField f v = case v of
-  Nothing -> ""
-  Just a  -> foldr BS.append "" ["\"", f, "\":", encodeUtf8 . pack . show $ a, ","]
 

--- a/test/Unit/ConnectSpec.hs
+++ b/test/Unit/ConnectSpec.hs
@@ -19,7 +19,7 @@ import           Types.Connect
 
 spec :: Spec
 spec = do
-  manual
+  generated
 
 boolCases = [True, False]
 maybeUserCases = [Just "samisagit", Just "sam@google.com", Nothing]
@@ -31,43 +31,44 @@ maybeJwtCases = [Just "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3
 maybeIntCases = [Just 1, Just 10, Nothing]
 maybeBoolCases = [Just True, Just False, Nothing]
 
-manual = parallel $ do
-  describe "transformer" $ do
-    forM_ boolCases $ \verbosity ->
-      forM_ boolCases $ \pedanticity ->
-        forM_ boolCases $ \tlsRequirement ->
-          forM_ maybeJwtCases $ \authTokenOptions ->
-            forM_ maybeUserCases $ \userOptions ->
-              forM_ maybePassCases $ \passOptions ->
-                forM_ maybeNameCases $ \nameOptions ->
-                  forM_ maybeIntCases $ \protocolOptions ->
-                    forM_ maybeBoolCases $ \echoOptions ->
-                      forM_ maybeSigCases $ \sigOptions ->
-                        forM_ maybeJwtCases $ \jwtOptions -> do
-                          let d = Connect verbosity pedanticity tlsRequirement authTokenOptions userOptions passOptions nameOptions "Haskell" 1 protocolOptions echoOptions sigOptions jwtOptions
-                          it (printf "transforms %v successfully" (show d)) $ \f -> do
-                            let transformed = transform d
-                            let proto = BS.take 7 transformed
-                            let json = BS.drop 8 transformed
-                            proto `shouldBe` "CONNECT"
-                            let expectedFields = BS.init $ foldr BS.append "" [
-                                  collapseMaybeStringField "auth_token" authTokenOptions,
-                                  collapseMaybeBoolField "echo" echoOptions,
-                                  collapseMaybeStringField "jwt" jwtOptions,
-                                  collapseMaybeStringField "lang" (Just "Haskell"),
-                                  collapseMaybeStringField "name" nameOptions,
-                                  collapseMaybeStringField "pass" passOptions,
-                                  collapseMaybeBoolField "pedantic" (Just pedanticity),
-                                  collapseMaybeIntField "protocol" protocolOptions,
-                                  collapseMaybeStringField "sig" sigOptions,
-                                  collapseMaybeBoolField "tls_required" (Just tlsRequirement),
-                                  collapseMaybeStringField "user" userOptions,
-                                  collapseMaybeBoolField "verbose" (Just verbosity),
-                                  collapseMaybeIntField "version" (Just 1)
-                                  ]
-                            let decoded = decode . LBS.fromStrict $ json :: Maybe Value
-                            let want = (decode . LBS.fromStrict $ foldr BS.append "" ["{", expectedFields, "}"]) :: Maybe Value
-                            decoded `shouldBe` want
+generated = parallel $ do
+  describe "generated" $ do
+    describe "transformer" $ do
+      forM_ boolCases $ \verbosity ->
+        forM_ boolCases $ \pedanticity ->
+          forM_ boolCases $ \tlsRequirement ->
+            forM_ maybeJwtCases $ \authTokenOptions ->
+              forM_ maybeUserCases $ \userOptions ->
+                forM_ maybePassCases $ \passOptions ->
+                  forM_ maybeNameCases $ \nameOptions ->
+                    forM_ maybeIntCases $ \protocolOptions ->
+                      forM_ maybeBoolCases $ \echoOptions ->
+                        forM_ maybeSigCases $ \sigOptions ->
+                          forM_ maybeJwtCases $ \jwtOptions -> do
+                            let d = Connect verbosity pedanticity tlsRequirement authTokenOptions userOptions passOptions nameOptions "Haskell" 1 protocolOptions echoOptions sigOptions jwtOptions
+                            it (printf "transforms %v successfully" (show d)) $ \f -> do
+                              let transformed = transform d
+                              let proto = BS.take 7 transformed
+                              let json = BS.drop 8 transformed
+                              proto `shouldBe` "CONNECT"
+                              let expectedFields = BS.init $ foldr BS.append "" [
+                                    collapseMaybeStringField "auth_token" authTokenOptions,
+                                    collapseMaybeBoolField "echo" echoOptions,
+                                    collapseMaybeStringField "jwt" jwtOptions,
+                                    collapseMaybeStringField "lang" (Just "Haskell"),
+                                    collapseMaybeStringField "name" nameOptions,
+                                    collapseMaybeStringField "pass" passOptions,
+                                    collapseMaybeBoolField "pedantic" (Just pedanticity),
+                                    collapseMaybeIntField "protocol" protocolOptions,
+                                    collapseMaybeStringField "sig" sigOptions,
+                                    collapseMaybeBoolField "tls_required" (Just tlsRequirement),
+                                    collapseMaybeStringField "user" userOptions,
+                                    collapseMaybeBoolField "verbose" (Just verbosity),
+                                    collapseMaybeIntField "version" (Just 1)
+                                    ]
+                              let decoded = decode . LBS.fromStrict $ json :: Maybe Value
+                              let want = (decode . LBS.fromStrict $ foldr BS.append "" ["{", expectedFields, "}"]) :: Maybe Value
+                              decoded `shouldBe` want
 
 collapseMaybeStringField :: BS.ByteString -> Maybe Text -> BS.ByteString
 collapseMaybeStringField f v  = case v of

--- a/test/Unit/ConnectSpec.hs
+++ b/test/Unit/ConnectSpec.hs
@@ -22,39 +22,31 @@ spec :: Spec
 spec = do
   explicit
 
-explicitCases :: [Connect]
+explicitCases :: [(BS.ByteString, Connect)]
 explicitCases = [
-  Connect False False False Nothing Nothing Nothing Nothing "" 1 Nothing Nothing Nothing Nothing,
-  Connect True True True (Just "token") (Just "user") (Just "pass") (Just "name") "Haskell" 1 (Just 3) (Just True) (Just "sig") (Just "jwt")
+  (
+    "CONNECT {\"verbose\": false, \"pedantic\": false, \"tls_required\": false, \"lang\": \"Haskell\", \"version\": 1}",
+    Connect False False False Nothing Nothing Nothing Nothing "Haskell" 1 Nothing Nothing Nothing Nothing
+    ),
+  (
+    "CONNECT {\"verbose\": true, \"pedantic\": true, \"tls_required\": true, \"auth_token\": \"token\", \"user\": \"user\", \"pass\": \"pass\", \"name\": \"name\", \"lang\": \"Haskell\", \"version\": 1, \"protocol\": 3, \"echo\": true, \"sig\": \"sig\", \"jwt\": \"jwt\"}",
+    Connect True True True (Just "token") (Just "user") (Just "pass") (Just "name") "Haskell" 1 (Just 3) (Just True) (Just "sig") (Just "jwt")
+    )
   ]
 
--- TODO: we should make this JSON explicit rather than building fields
 explicit = parallel $ do
   describe "transformer" $ do
-    forM_ explicitCases $ \input -> do
+    forM_ explicitCases $ \(want, input) -> do
       it (printf "transforms %v successfully" (show input)) $ \f -> do
+
         let transformed = transform input
-        let proto = BS.take 7 transformed
-        let json = BS.drop 8 transformed
-        let expectedFields = BS.init $ foldr BS.append "FIX ME " [
---              collapseMaybeStringField "auth_token" $ auth_token input,
---              collapseMaybeBoolField "echo" $ echo input,
---              collapseMaybeStringField "jwt" $ jwt input,
---              collapseMaybeStringField "lang" (Just $ lang input),
---              collapseMaybeStringField "name" $ name input,
---              collapseMaybeStringField "pass" $ pass input,
---              collapseMaybeBoolField "pedantic" (Just $ pedantic input),
---              collapseMaybeIntField "protocol" $ protocol input,
---              collapseMaybeStringField "sig" $ sig input,
---              collapseMaybeBoolField "tls_required" (Just $ tls_required input),
---              collapseMaybeStringField "user" $ user input,
---              collapseMaybeBoolField "verbose" (Just $ verbose input),
---              collapseMaybeIntField "version" (Just $ version input)
-              ]
-        -- we don't really care about field order, nor do we want to ensure it in the test
-        -- so we'll just decode the want and the got into a Haskell type and check they're equal
-        let want = (decode . LBS.fromStrict $ foldr BS.append "" ["{", expectedFields, "}"]) :: Maybe Value
-        let got = decode . LBS.fromStrict $ json :: Maybe Value
-        proto `shouldBe` "CONNECT"
-        got `shouldBe` want
+
+        let gotProto = BS.take 7 transformed
+        let gotJSONString = BS.drop 8 transformed
+
+        let wantJSON = decode . LBS.fromStrict $ BS.drop 8 want :: Maybe Value
+        let gotJSON = decode . LBS.fromStrict $ gotJSONString :: Maybe Value
+
+        gotProto `shouldBe` "CONNECT"
+        gotJSON `shouldBe` wantJSON
 

--- a/test/Unit/ConnectSpec.hs
+++ b/test/Unit/ConnectSpec.hs
@@ -18,12 +18,16 @@ spec = do
 explicitCases :: [(Connect, BS.ByteString)]
 explicitCases = [
   (
-    Connect False False False Nothing Nothing Nothing Nothing "Haskell" 1 Nothing Nothing Nothing Nothing,
-    "CONNECT {\"verbose\": false, \"pedantic\": false, \"tls_required\": false, \"lang\": \"Haskell\", \"version\": 1}"
+    Connect False False False Nothing Nothing Nothing Nothing "Haskell" "1" Nothing Nothing Nothing Nothing,
+    "CONNECT {\"verbose\": false, \"pedantic\": false, \"tls_required\": false, \"lang\": \"Haskell\", \"version\": \"1\"}"
     ),
   (
-    Connect True True True (Just "token") (Just "user") (Just "pass") (Just "name") "Haskell" 1 (Just 3) (Just True) (Just "sig") (Just "jwt"),
-    "CONNECT {\"verbose\": true, \"pedantic\": true, \"tls_required\": true, \"auth_token\": \"token\", \"user\": \"user\", \"pass\": \"pass\", \"name\": \"name\", \"lang\": \"Haskell\", \"version\": 1, \"protocol\": 3, \"echo\": true, \"sig\": \"sig\", \"jwt\": \"jwt\"}"
+    Connect True True True (Just "token") (Just "user") (Just "pass") (Just "name") "Haskell" "1" (Just 3) (Just True) (Just "sig") (Just "jwt"),
+    "CONNECT {\"verbose\": true, \"pedantic\": true, \"tls_required\": true, \"auth_token\": \"token\", \"user\": \"user\", \"pass\": \"pass\", \"name\": \"name\", \"lang\": \"Haskell\", \"version\": \"1\", \"protocol\": 3, \"echo\": true, \"sig\": \"sig\", \"jwt\": \"jwt\"}"
+    ),
+  (
+    Connect True True True (Just "token") (Just "user") (Just "pass") (Just "name") "Haskell" "1.0.0" (Just 3) (Just True) (Just "sig") (Just "jwt"),
+    "CONNECT {\"verbose\": true, \"pedantic\": true, \"tls_required\": true, \"auth_token\": \"token\", \"user\": \"user\", \"pass\": \"pass\", \"name\": \"name\", \"lang\": \"Haskell\", \"version\": \"1.0.0\", \"protocol\": 3, \"echo\": true, \"sig\": \"sig\", \"jwt\": \"jwt\"}"
     )
   ]
 

--- a/test/Unit/ErrSpec.hs
+++ b/test/Unit/ErrSpec.hs
@@ -3,9 +3,7 @@
 module ErrSpec (spec) where
 
 import           Control.Monad
-import qualified Data.ByteString    as BS
-import qualified Data.Text          as T
-import           Data.Text.Encoding (encodeUtf8)
+import qualified Data.ByteString as BS
 import           Fixtures
 import           Lib.Parser
 import           Parsers.Parsers

--- a/test/Unit/ErrSpec.hs
+++ b/test/Unit/ErrSpec.hs
@@ -56,15 +56,19 @@ explicit = parallel $ do
         let output = genericParse input
         output `shouldBe` Just (ParsedErr expected)
 
+
 generated = parallel $ do
   describe "generated" $ do
     describe "generic parser" $ do
       forM_ invalidSubjectCases $ \subject -> do
-        let subInput = foldr BS.append "-ERR 'Permissions Violation For Subscription To " [subject, "'\r\n"]
+        let subInput = foldr BS.append "" ["-ERR 'Permissions Violation For Subscription To ", subject, "'\r\n"]
         let subExpected = Err (BS.init . BS.init . BS.init . BS.drop 6 $ subInput) False
         it (printf "correctly parses %s" (show subInput)) $ do
           let output = genericParse subInput
           output `shouldBe` Just (ParsedErr subExpected)
-        it (printf "correctly parses %s" (show subInput)) $ do
-          let output = genericParse subInput
-          output `shouldBe` Just (ParsedErr subExpected)
+      forM_ invalidSubjectCases $ \subject -> do
+        let pubInput = foldr BS.append "" ["-ERR 'Permissions Violation For Publish To ", subject, "'\r\n"]
+        let pubExpected = Err (BS.init . BS.init . BS.init . BS.drop 6 $ pubInput) False
+        it (printf "correctly parses %s" (show pubInput)) $ do
+          let output = genericParse pubInput
+          output `shouldBe` Just (ParsedErr pubExpected)

--- a/test/Unit/ErrSpec.hs
+++ b/test/Unit/ErrSpec.hs
@@ -60,13 +60,11 @@ generated = parallel $ do
   describe "generated" $ do
     describe "generic parser" $ do
       forM_ invalidSubjectCases $ \subject -> do
-        let subInput = encodeUtf8 . T.pack $ "-ERR 'Permissions Violation For Subscription To " ++ subject ++ "'\r\n"
+        let subInput = foldr BS.append "-ERR 'Permissions Violation For Subscription To " [subject, "'\r\n"]
         let subExpected = Err (BS.init . BS.init . BS.init . BS.drop 6 $ subInput) False
         it (printf "correctly parses %s" (show subInput)) $ do
           let output = genericParse subInput
           output `shouldBe` Just (ParsedErr subExpected)
-        let subInput = encodeUtf8 . T.pack $ "-ERR 'Permissions Violation For Publish To " ++ subject ++ "'\r\n"
-        let subExpected = Err (BS.init . BS.init . BS.init . BS.drop 6 $ subInput) False
         it (printf "correctly parses %s" (show subInput)) $ do
           let output = genericParse subInput
           output `shouldBe` Just (ParsedErr subExpected)

--- a/test/Unit/ErrSpec.hs
+++ b/test/Unit/ErrSpec.hs
@@ -5,14 +5,13 @@ module ErrSpec (spec) where
 import           Control.Monad
 import qualified Data.ByteString as BS
 import           Fixtures
-import           Lib.Parser
 import           Parsers.Parsers
 import           Test.Hspec
 import           Text.Printf
 import           Types.Err
 
-cases :: [(BS.ByteString, Err)]
-cases = [
+explicitCases :: [(BS.ByteString, Err)]
+explicitCases = [
   ("-ERR 'Unknown Protocol Operation'\r\n", Err "Unknown Protocol Operation" True),
   ("-ERR 'Attempted To Connect To Route Port'\r\n", Err "Attempted To Connect To Route Port" True),
   ("-ERR 'Authorization Violation'\r\n", Err "Authorization Violation" True),
@@ -30,43 +29,23 @@ cases = [
   ("-ERR 'Permissions Violation For Publish To FOO.'\r\n", Err "Permissions Violation For Publish To FOO." False)
   ]
 
+generatedCases =
+  zip
+    ((\x n-> foldr BS.append "" ["-ERR 'Permissions Violation For ", x, " To ", n, "'\r\n"]) <$> ["Subscription", "Publish"] <*> invalidSubjectCases)
+    ((\x n-> Err $ foldr BS.append "" ["Permissions Violation For ", x, " To ", n]) <$> ["Subscription", "Publish"] <*> invalidSubjectCases <*> [False])
+
 spec :: Spec
 spec = do
-  explicit
-  generated
+  cases
 
-explicit = parallel $ do
-  describe "specific parser" $ do
-    forM_ cases $ \(input, expected) ->
-      it (printf "correctly parses %s" (show input)) $ do
-        let output = runParser errParser input
-        let result = fmap fst output
-        let rest = fmap snd output
-        case result of
-          Just (ParsedErr a) -> a `shouldBe` expected
-          Nothing            -> error "parser did not return ERR type"
-        case rest of
-          Just "" -> return ()
-          _       -> error "parser did not consume all tokens"
+cases = parallel $ do
   describe "generic parser" $ do
-    forM_ cases $ \(input, expected) ->
-      it (printf "correctly parses %s" (show input)) $ do
+    forM_ explicitCases $ \(input, want) ->
+      it (printf "correctly parses explicit case %s" (show input)) $ do
         let output = genericParse input
-        output `shouldBe` Just (ParsedErr expected)
+        output `shouldBe` Just (ParsedErr want)
+    forM_ generatedCases $ \(input, want) ->
+      it (printf "correctly parses generated case %s" (show input)) $ do
+        let output = genericParse input
+        output `shouldBe` Just (ParsedErr want)
 
-
-generated = parallel $ do
-  describe "generated" $ do
-    describe "generic parser" $ do
-      forM_ invalidSubjectCases $ \subject -> do
-        let subInput = foldr BS.append "" ["-ERR 'Permissions Violation For Subscription To ", subject, "'\r\n"]
-        let subExpected = Err (BS.init . BS.init . BS.init . BS.drop 6 $ subInput) False
-        it (printf "correctly parses %s" (show subInput)) $ do
-          let output = genericParse subInput
-          output `shouldBe` Just (ParsedErr subExpected)
-      forM_ invalidSubjectCases $ \subject -> do
-        let pubInput = foldr BS.append "" ["-ERR 'Permissions Violation For Publish To ", subject, "'\r\n"]
-        let pubExpected = Err (BS.init . BS.init . BS.init . BS.drop 6 $ pubInput) False
-        it (printf "correctly parses %s" (show pubInput)) $ do
-          let output = genericParse pubInput
-          output `shouldBe` Just (ParsedErr pubExpected)

--- a/test/Unit/Fixtures.hs
+++ b/test/Unit/Fixtures.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Fixtures where
+
+import qualified Data.ByteString    as BS
+import           Data.Text          (Text, pack)
+import           Data.Text.Encoding
+import           Text.Printf
+
+versionCases = ["0.0.0", "v1.0.1", "13.0.0+123"]
+boolCases = [True, False]
+userCases = ["samisagit", "sam@google.com"]
+passCases = ["dsalkj09898(*)(UHJHI&*&*)(910"]
+nameCases = ["natskell-client"]
+sigCases = ["eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQSflKxwRJSMeKKF2QT4fwpMeJf36POk6yJVadQssw5c"]
+jwtCases = ["eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"]
+intCases = [1]
+goVersionCases = ["1.17"]
+hostCases = ["192.168.1.7"]
+portCases = [4222]
+serverIDCases = ["123"]
+maxPayloadCases = [1024]
+protocolCases = [1,2,3]
+clientIDCases = [1, 100]
+connectStringCases = [[], ["127.0.0.1"], ["127.0.0.1:4222", "0.0.0.0:4222"]]
+
+maybeify :: [a] -> [Maybe a]
+maybeify xs = Nothing : fmap Just xs
+
+collapseMaybeStringField :: BS.ByteString -> Maybe Text -> BS.ByteString
+collapseMaybeStringField f v  = case v of
+  Nothing -> ""
+  Just a  -> foldr BS.append "" ["\"", f, "\":", "\"", encodeUtf8 a, "\","]
+
+collapseMaybeBoolField :: BS.ByteString -> Maybe Bool -> BS.ByteString
+collapseMaybeBoolField f v  = case v of
+  Nothing    -> ""
+  Just True  -> foldr BS.append "" ["\"", f, "\":", "true,"]
+  Just False -> foldr BS.append "" ["\"", f, "\":", "false,"]
+
+collapseMaybeIntField :: BS.ByteString -> Maybe Int -> BS.ByteString
+collapseMaybeIntField f v = case v of
+  Nothing -> ""
+  Just a  -> foldr BS.append "" ["\"", f, "\":", encodeUtf8 . pack . show $ a, ","]
+
+collapseMaybeStringListField :: BS.ByteString -> Maybe [String] -> BS.ByteString
+collapseMaybeStringListField f v  = case v of
+  Nothing -> ""
+  Just [] -> foldr BS.append "" ["\"", f, "\"", ":[],"]
+  Just a  -> foldr BS.append "" ["\"", f, "\"", ":[", encodeUtf8 . pack $ formattedItems, "]", ","]
+    where
+      formattedItems = init $ concatMap (printf "\"%s\",") a :: String
+

--- a/test/Unit/Fixtures.hs
+++ b/test/Unit/Fixtures.hs
@@ -2,11 +2,7 @@
 
 module Fixtures where
 
-import qualified Data.ByteString    as BS
-import           Data.Text          (Text, pack)
-import qualified Data.Text          as T
-import           Data.Text.Encoding
-import           Text.Printf
+import qualified Data.ByteString as BS
 
 versionCases :: [BS.ByteString]
 versionCases = ["0.0.0", "v1.0.1", "13.0.0+123"]
@@ -45,6 +41,10 @@ protocolCases :: [Int]
 protocolCases = [1,2,3]
 clientIDCases :: [Int]
 clientIDCases = [1, 100]
+
+sidCases :: [BS.ByteString]
+sidCases = ["1", "100", "abc", "abc123"]
+
 connectStringCases :: [[BS.ByteString]]
 connectStringCases = [[], ["127.0.0.1"], ["127.0.0.1:4222", "0.0.0.0:4222"]]
 
@@ -55,7 +55,7 @@ invalidSubjectCases :: [BS.ByteString]
 invalidSubjectCases = [" FOO", "FOO>BAR", "FOO ", "F OO", "FOO.**"]
 
 payloadCases :: [(Int, Maybe BS.ByteString)]
-payloadCases = [(12, Just "some payload"), (23, Just "some\r\nmulti line payload"), (41, Just ".*some payload ** with specials chars > *"), (0, Nothing)]
+payloadCases = [(12, Just "some payload"), (24, Just "some\r\nmulti line payload"), (41, Just ".*some payload ** with specials chars > *"), (0, Nothing)]
 
 maybeify :: [a] -> [Maybe a]
 maybeify xs = Nothing : fmap Just xs

--- a/test/Unit/Fixtures.hs
+++ b/test/Unit/Fixtures.hs
@@ -23,6 +23,8 @@ maxPayloadCases = [1024]
 protocolCases = [1,2,3]
 clientIDCases = [1, 100]
 connectStringCases = [[], ["127.0.0.1"], ["127.0.0.1:4222", "0.0.0.0:4222"]]
+subjectCases = ["FOO", "FOO.BAR", "FOO.BAR.>", ">", "foo.bar", "123.456", "FOO.*.BAR", "FOO.*.BAR.*.>"]
+invalidSubjectCases = [" FOO", "FOO>BAR", "FOO ", "F OO", "FOO.**"]
 
 maybeify :: [a] -> [Maybe a]
 maybeify xs = Nothing : fmap Just xs

--- a/test/Unit/Fixtures.hs
+++ b/test/Unit/Fixtures.hs
@@ -4,52 +4,59 @@ module Fixtures where
 
 import qualified Data.ByteString    as BS
 import           Data.Text          (Text, pack)
+import qualified Data.Text          as T
 import           Data.Text.Encoding
 import           Text.Printf
 
+versionCases :: [BS.ByteString]
 versionCases = ["0.0.0", "v1.0.1", "13.0.0+123"]
+
 boolCases = [True, False]
+
+userCases :: [BS.ByteString]
 userCases = ["samisagit", "sam@google.com"]
+
+passCases :: [BS.ByteString]
 passCases = ["dsalkj09898(*)(UHJHI&*&*)(910"]
+
+nameCases :: [BS.ByteString]
 nameCases = ["natskell-client"]
+
+sigCases :: [BS.ByteString]
 sigCases = ["eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQSflKxwRJSMeKKF2QT4fwpMeJf36POk6yJVadQssw5c"]
+
+jwtCases :: [BS.ByteString]
 jwtCases = ["eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"]
-intCases = [1]
+
+goVersionCases :: [BS.ByteString]
 goVersionCases = ["1.17"]
+
+hostCases :: [BS.ByteString]
 hostCases = ["192.168.1.7"]
-portCases = [4222]
+
+serverIDCases :: [BS.ByteString]
 serverIDCases = ["123"]
-maxPayloadCases = [1024]
+
+portCases :: [Int]
+portCases = [4222]
+maxPayloadCases :: [Int]
+maxPayloadCases = [0, 512, 1024]
+protocolCases :: [Int]
 protocolCases = [1,2,3]
+clientIDCases :: [Int]
 clientIDCases = [1, 100]
+connectStringCases :: [[BS.ByteString]]
 connectStringCases = [[], ["127.0.0.1"], ["127.0.0.1:4222", "0.0.0.0:4222"]]
+
+subjectCases :: [BS.ByteString]
 subjectCases = ["FOO", "FOO.BAR", "FOO.BAR.>", ">", "foo.bar", "123.456", "FOO.*.BAR", "FOO.*.BAR.*.>"]
+
+invalidSubjectCases :: [BS.ByteString]
 invalidSubjectCases = [" FOO", "FOO>BAR", "FOO ", "F OO", "FOO.**"]
+
+payloadCases :: [(Int, Maybe BS.ByteString)]
+payloadCases = [(12, Just "some payload"), (23, Just "some\r\nmulti line payload"), (41, Just ".*some payload ** with specials chars > *"), (0, Nothing)]
 
 maybeify :: [a] -> [Maybe a]
 maybeify xs = Nothing : fmap Just xs
-
-collapseMaybeStringField :: BS.ByteString -> Maybe Text -> BS.ByteString
-collapseMaybeStringField f v  = case v of
-  Nothing -> ""
-  Just a  -> foldr BS.append "" ["\"", f, "\":", "\"", encodeUtf8 a, "\","]
-
-collapseMaybeBoolField :: BS.ByteString -> Maybe Bool -> BS.ByteString
-collapseMaybeBoolField f v  = case v of
-  Nothing    -> ""
-  Just True  -> foldr BS.append "" ["\"", f, "\":", "true,"]
-  Just False -> foldr BS.append "" ["\"", f, "\":", "false,"]
-
-collapseMaybeIntField :: BS.ByteString -> Maybe Int -> BS.ByteString
-collapseMaybeIntField f v = case v of
-  Nothing -> ""
-  Just a  -> foldr BS.append "" ["\"", f, "\":", encodeUtf8 . pack . show $ a, ","]
-
-collapseMaybeStringListField :: BS.ByteString -> Maybe [String] -> BS.ByteString
-collapseMaybeStringListField f v  = case v of
-  Nothing -> ""
-  Just [] -> foldr BS.append "" ["\"", f, "\"", ":[],"]
-  Just a  -> foldr BS.append "" ["\"", f, "\"", ":[", encodeUtf8 . pack $ formattedItems, "]", ","]
-    where
-      formattedItems = init $ concatMap (printf "\"%s\",") a :: String
 

--- a/test/Unit/InfoSpec.hs
+++ b/test/Unit/InfoSpec.hs
@@ -14,6 +14,37 @@ import           Types.Info
 spec :: Spec
 spec = do
   manual
+  generated
+
+serverIDCases = ["serverA", "server A", "d9b3a74c-21f2-424f-9613-c3e8c6649455", "123"]
+versionCases = ["1", "1.1.1", "v3.2.1", "1.11.1+1658688064", "v1.11.1+1658688064", "d9b3a74c-21f2-424f-9613-c3e8c6649455", "123"]
+goVersionCases = ["1", "1.17", "2.0"]
+hostCases = ["127.0.0.1", "168.212.226.204"]
+portCases = [4222, 8080, 81, 65535]
+maxPayloadCases = [1024, 512, 256, 128, 64, 32, 16, 8]
+protocolCases = [1, 2, 3]
+clientIDCases = [Just 1, Just 100, Nothing]
+maybeBoolCases = [Just True, Just False, Nothing]
+connectStringsCases = [Just [], Just ["127.0.0.1:4222"], Just ["127.0.0.1:4222", "0.0.0.0:1234"],  Nothing]
+
+generated = parallel $ do
+  describe "generated" $ do
+    describe "specific parser" $ do
+      forM_ serverIDCases $ \serverID ->
+        forM_ versionCases $ \version ->
+          forM_ goVersionCases $ \goVersion ->
+            forM_ hostCases $ \ host ->
+              forM_ portCases $ \port ->
+                forM_ maxPayloadCases $ \maxPayload ->
+                  forM_ protocolCases $ \protocol ->
+                    forM_ clientIDCases $ \clientID ->
+                      forM_ maybeBoolCases $ \authRequired ->
+                        forM_ maybeBoolCases $ \tlsRequired ->
+                          forM_ connectStringsCases $ \connectStrings ->
+                            forM_ maybeBoolCases $ \ldm -> do
+                              it "parses INFO..." $ do
+--                                let info = Info serverID version goVersion host port maxPayload protocol clientID authRequired tlsRequired connectStrings ldm
+                                1 `shouldBe` 1
 
 cases :: [(BS.ByteString, Info, String)]
 cases = [

--- a/test/Unit/InfoSpec.hs
+++ b/test/Unit/InfoSpec.hs
@@ -35,22 +35,22 @@ generated = parallel $ do
                           forM_ (maybeify connectStringCases) $ \connectStrings ->
                             forM_ (maybeify boolCases )$ \ldm -> do
                               let inputFields = BS.init $ foldr BS.append "" [
-                                   collapseMaybeStringField "server_id" (Just $ pack serverID),
-                                   collapseMaybeStringField "version" (Just $ pack version),
-                                   collapseMaybeStringField "go" (Just $ pack goVersion),
-                                   collapseMaybeStringField "host" (Just $ pack host),
-                                   collapseMaybeIntField "port" (Just $ fromIntegral port),
-                                   collapseMaybeIntField "max_payload" (Just $ fromIntegral maxPayload),
-                                   collapseMaybeIntField "proto" (Just $ fromIntegral protocol),
-                                   collapseMaybeIntField "client_id" $ Just $ fromIntegral clientID,
-                                   collapseMaybeBoolField "auth_required" authRequired,
-                                   collapseMaybeBoolField "tls_required" tlsRequired,
-                                   collapseMaybeStringListField "connect_urls" connectStrings,
-                                   collapseMaybeBoolField "ldm" ldm
+--                                   collapseMaybeStringField "server_id" (Just $ pack serverID),
+--                                   collapseMaybeStringField "version" (Just $ pack version),
+--                                   collapseMaybeStringField "go" (Just $ pack goVersion),
+--                                   collapseMaybeStringField "host" (Just $ pack host),
+--                                   collapseMaybeIntField "port" (Just $ fromIntegral port),
+--                                   collapseMaybeIntField "max_payload" (Just $ fromIntegral maxPayload),
+--                                   collapseMaybeIntField "proto" (Just $ fromIntegral protocol),
+--                                   collapseMaybeIntField "client_id" $ Just $ fromIntegral clientID,
+--                                   collapseMaybeBoolField "auth_required" authRequired,
+--                                   collapseMaybeBoolField "tls_required" tlsRequired,
+--                                   collapseMaybeStringListField "connect_urls" connectStrings,
+--                                   collapseMaybeBoolField "ldm" ldm
                                    ]
                               let input = foldr BS.append "" ["INFO {", inputFields, "}\r\n"]
                               it (printf "parses %s successfully" (show input)) $ \f -> do
-                                let expected = Info (pack serverID) (pack version) (pack goVersion) (pack host) (fromIntegral port) (fromIntegral maxPayload) (fromIntegral protocol) (Just $ fromIntegral clientID) authRequired tlsRequired connectStrings ldm
+                                let expected = Info serverID version goVersion host port maxPayload protocol (Just clientID) authRequired tlsRequired connectStrings ldm
                                 let output = genericParse input
                                 output `shouldBe` Just (ParsedInfo expected)
 

--- a/test/Unit/InfoSpec.hs
+++ b/test/Unit/InfoSpec.hs
@@ -2,12 +2,9 @@
 
 module InfoSpec (spec) where
 
+import           Control.Exception
 import           Control.Monad
-import           Data.Aeson
-import qualified Data.ByteString    as BS
-import           Data.Text          (Text, pack)
-import           Data.Text.Encoding
-import           Fixtures
+import qualified Data.ByteString   as BS
 import           Lib.Parser
 import           Parsers.Parsers
 import           Test.Hspec
@@ -17,42 +14,42 @@ import           Types.Info
 spec :: Spec
 spec = do
   manual
-  generated
-
-generated = parallel $ do
-  describe "generated" $ do
-    describe "generic parser" $ do
-      forM_ serverIDCases $ \serverID ->
-        forM_ versionCases $ \version ->
-          forM_ goVersionCases $ \goVersion ->
-            forM_ hostCases $ \ host ->
-              forM_ portCases $ \port ->
-                forM_ maxPayloadCases $ \maxPayload ->
-                  forM_ protocolCases $ \protocol ->
-                    forM_ clientIDCases $ \clientID ->
-                      forM_ (maybeify boolCases) $ \authRequired ->
-                        forM_ (maybeify boolCases) $ \tlsRequired ->
-                          forM_ (maybeify connectStringCases) $ \connectStrings ->
-                            forM_ (maybeify boolCases )$ \ldm -> do
-                              let inputFields = BS.init $ foldr BS.append "" [
---                                   collapseMaybeStringField "server_id" (Just $ pack serverID),
---                                   collapseMaybeStringField "version" (Just $ pack version),
---                                   collapseMaybeStringField "go" (Just $ pack goVersion),
---                                   collapseMaybeStringField "host" (Just $ pack host),
---                                   collapseMaybeIntField "port" (Just $ fromIntegral port),
---                                   collapseMaybeIntField "max_payload" (Just $ fromIntegral maxPayload),
---                                   collapseMaybeIntField "proto" (Just $ fromIntegral protocol),
---                                   collapseMaybeIntField "client_id" $ Just $ fromIntegral clientID,
---                                   collapseMaybeBoolField "auth_required" authRequired,
---                                   collapseMaybeBoolField "tls_required" tlsRequired,
---                                   collapseMaybeStringListField "connect_urls" connectStrings,
---                                   collapseMaybeBoolField "ldm" ldm
-                                   ]
-                              let input = foldr BS.append "" ["INFO {", inputFields, "}\r\n"]
-                              it (printf "parses %s successfully" (show input)) $ \f -> do
-                                let expected = Info serverID version goVersion host port maxPayload protocol (Just clientID) authRequired tlsRequired connectStrings ldm
-                                let output = genericParse input
-                                output `shouldBe` Just (ParsedInfo expected)
+--  generated
+--
+--generated = parallel $ do
+--  describe "generated" $ do
+--    describe "generic parser" $ do
+--      forM_ serverIDCases $ \serverID ->
+--        forM_ versionCases $ \version ->
+--          forM_ goVersionCases $ \goVersion ->
+--            forM_ hostCases $ \ host ->
+--              forM_ portCases $ \port ->
+--                forM_ maxPayloadCases $ \maxPayload ->
+--                  forM_ protocolCases $ \protocol ->
+--                    forM_ clientIDCases $ \clientID ->
+--                      forM_ (maybeify boolCases) $ \authRequired ->
+--                        forM_ (maybeify boolCases) $ \tlsRequired ->
+--                          forM_ (maybeify connectStringCases) $ \connectStrings ->
+--                            forM_ (maybeify boolCases )$ \ldm -> do
+--                              let inputFields = BS.init $ foldr BS.append "" [
+----                                   collapseMaybeStringField "server_id" (Just $ pack serverID),
+----                                   collapseMaybeStringField "version" (Just $ pack version),
+----                                   collapseMaybeStringField "go" (Just $ pack goVersion),
+----                                   collapseMaybeStringField "host" (Just $ pack host),
+----                                   collapseMaybeIntField "port" (Just $ fromIntegral port),
+----                                   collapseMaybeIntField "max_payload" (Just $ fromIntegral maxPayload),
+----                                   collapseMaybeIntField "proto" (Just $ fromIntegral protocol),
+----                                   collapseMaybeIntField "client_id" $ Just $ fromIntegral clientID,
+----                                   collapseMaybeBoolField "auth_required" authRequired,
+----                                   collapseMaybeBoolField "tls_required" tlsRequired,
+----                                   collapseMaybeStringListField "connect_urls" connectStrings,
+----                                   collapseMaybeBoolField "ldm" ldm
+--                                   ]
+--                              let input = foldr BS.append "" ["INFO {", inputFields, "}\r\n"]
+--                              it (printf "parses %s successfully" (show input)) $ \f -> do
+--                                let expected = Info serverID version goVersion host port maxPayload protocol (Just clientID) authRequired tlsRequired connectStrings ldm
+--                                let output = genericParse input
+--                                output `shouldBe` Just (ParsedInfo expected)
 
 cases :: [(BS.ByteString, Info, String)]
 cases = [
@@ -62,8 +59,8 @@ cases = [
     "fully populated"
   ),
   (
-    "INFO {\"server_id\": \"some-server\", \"version\": \"semver\", \"go\": \"1.13\", \"host\": \"127.0.0.1\", \"port\": 4222, \"max_payload\": 1024, \"proto\": 3, \"auth_required\": true, \"tls_required\": true, \"ldm\": true}\r\n",
-    Info "some-server" "semver" "1.13" "127.0.0.1" 4222 1024 3 Nothing (Just True) (Just True) Nothing (Just True),
+    "INFO {\"server_id\": \"some-server\", \"version\": \"semver\", \"go\": \"1.13\", \"host\": \"127.0.0.1\", \"port\": 4222, \"max_payload\": 1024, \"proto\": 3}\r\n",
+    Info "some-server" "semver" "1.13" "127.0.0.1" 4222 1024 3 Nothing Nothing Nothing Nothing Nothing,
     "minimal"
   ),
   (
@@ -77,6 +74,10 @@ manual = parallel $ do
   describe "specific parser" $ do
     forM_ cases $ \(input, expected, name) ->
       it (printf "parses %s case successfully" name) $ do
+        output' <- try (evaluate (runParser infoParser input)) :: IO (Either SomeException (Maybe (ParsedMessage, BS.ByteString)))
+        case output' of
+          Left ex -> error $ show ex
+          Right m -> return ()
         let output = runParser infoParser input
         let result = fmap fst output
         let rest = fmap snd output
@@ -91,4 +92,3 @@ manual = parallel $ do
       it (printf "parses %s case successfully" name) $ do
         let output = genericParse input
         output `shouldBe` Just (ParsedInfo expected)
-

--- a/test/Unit/MsgSpec.hs
+++ b/test/Unit/MsgSpec.hs
@@ -7,7 +7,6 @@ import qualified Data.ByteString    as BS
 import qualified Data.Text          as T
 import           Data.Text.Encoding (encodeUtf8)
 import           Fixtures
-import           Lib.Parser
 import           Parsers.Parsers
 import           Test.Hspec
 import           Text.Printf
@@ -16,11 +15,10 @@ import           Types.Msg
 
 spec :: Spec
 spec = do
-  explicit
-  applicative
+  cases
 
-cases :: [(BS.ByteString, Msg)]
-cases = [
+explicitCases :: [(BS.ByteString, Msg)]
+explicitCases = [
   ("MSG FOO 13 BAR 17\r\nsome payload bits\r\n", Msg "FOO" "13" (Just "BAR") 17 (Just "some payload bits")),
   ("MSG FOO 13 BAR 0\r\n", Msg "FOO" "13" (Just "BAR") 0 Nothing),
   ("MSG FOO 13 17\r\nsome payload bits\r\n", Msg "FOO" "13" Nothing 17 (Just"some payload bits")),
@@ -29,39 +27,25 @@ cases = [
   ("MSG FOO.BAR.BAZ 13 IN.*.BOX.> 0\r\n", Msg "FOO.BAR.BAZ" "13" (Just "IN.*.BOX.>") 0 Nothing)
   ]
 
-explicit = parallel $ do
-  forM_ cases $ \(input, expected) -> do
-    describe "specific parser" $ do
-      it (printf "correctly parses %s" (show input)) $ do
-        let output = runParser msgParser input
-        let result = fmap fst output
-        let rest = fmap snd output
-        case result of
-          Just (ParsedMsg a) -> a `shouldBe` expected
-          Nothing            -> error "parser did not return MSG type"
-        case rest of
-          Just "" -> return ()
-          _       -> error "parser did not consume all tokens"
-    describe "generic parser" $ do
-      it (printf "correctly parses %s" (show input)) $ do
-        let output = genericParse input
-        output `shouldBe` Just (ParsedMsg expected)
-
-applicative = parallel $ do
-  describe "generated" $ do
-    describe "MSG parser" $ do
-      let msgs = map uncurry (Msg
+generatedCases :: [(BS.ByteString, Msg)]
+generatedCases = zip (map buildProtoInput msgs) msgs
+  where
+    msgs = map uncurry (Msg
             <$> subjectCases
             <*> sidCases
             <*> maybeify subjectCases)
             <*> payloadCases -- because byteCount and payload are in valid pairs we needed to uncurry this
-      let proto = map buildProtoInput msgs
-      let pairs = zip proto msgs
 
-      forM_ pairs $ \(input, want) -> do
-        it (printf "correctly parses %s" (show input)) $ do
-          let output = genericParse input
-          output `shouldBe` Just (ParsedMsg want)
+cases = parallel $ do
+  describe "generic parser" $ do
+    forM_ explicitCases $ \(input, want) -> do
+      it (printf "correctly parses explicit case %s" (show input)) $ do
+        let output = genericParse input
+        output `shouldBe` Just (ParsedMsg want)
+    forM_ generatedCases $ \(input, want) -> do
+      it (printf "correctly parses generated case %s" (show input)) $ do
+        let output = genericParse input
+        output `shouldBe` Just (ParsedMsg want)
 
 buildProtoInput :: Msg -> BS.ByteString
 buildProtoInput m = foldr BS.append "" [

--- a/test/Unit/MsgSpec.hs
+++ b/test/Unit/MsgSpec.hs
@@ -2,27 +2,37 @@
 
 module MsgSpec (spec) where
 
+import           ASCII              as A
+import           ASCII.Char         as AC
 import           Control.Monad
-import           Data.ByteString
+import qualified Data.ByteString    as BS
+import qualified Data.Text          as T
+import           Data.Text.Encoding (encodeUtf8)
+import           Fixtures
 import           Lib.Parser
 import           Parsers.Parsers
 import           Test.Hspec
 import           Text.Printf
 import           Types.Msg
 
-cases :: [(ByteString, Msg)]
+
+spec :: Spec
+spec = do
+  explicit
+
+cases :: [(BS.ByteString, Msg)]
 cases = [
-  ("MSG FOO 13 BAR 17\r\nsome payload bits\r\n", Msg "FOO" 13 (Just "BAR") 17 (Just "some payload bits")),
-  ("MSG FOO 13 BAR 0\r\n", Msg "FOO" 13 (Just "BAR") 0 Nothing),
-  ("MSG FOO 13 17\r\nsome payload bits\r\n", Msg "FOO" 13 Nothing 17 (Just"some payload bits")),
-  ("MSG FOO 13 0\r\n", Msg "FOO" 13 Nothing 0 Nothing),
-  ("MSG FOO 13 20\r\nmulti\r\nline\r\npayload\r\n", Msg "FOO" 13 Nothing 20 (Just "multi\r\nline\r\npayload")),
-  ("MSG FOO.BAR.BAZ 13 IN.*.BOX.> 0\r\n", Msg "FOO.BAR.BAZ" 13 (Just "IN.*.BOX.>") 0 Nothing)
+  ("MSG FOO 13 BAR 17\r\nsome payload bits\r\n", Msg "FOO" "13" (Just "BAR") 17 (Just "some payload bits")),
+  ("MSG FOO 13 BAR 0\r\n", Msg "FOO" "13" (Just "BAR") 0 Nothing),
+  ("MSG FOO 13 17\r\nsome payload bits\r\n", Msg "FOO" "13" Nothing 17 (Just"some payload bits")),
+  ("MSG FOO 13 0\r\n", Msg "FOO" "13" Nothing 0 Nothing),
+  ("MSG FOO 13 20\r\nmulti\r\nline\r\npayload\r\n", Msg "FOO" "13" Nothing 20 (Just "multi\r\nline\r\npayload")),
+  ("MSG FOO.BAR.BAZ 13 IN.*.BOX.> 0\r\n", Msg "FOO.BAR.BAZ" "13" (Just "IN.*.BOX.>") 0 Nothing)
   ]
 
-form = parallel $ do
-  describe "specific parser" $ do
-    forM_ cases $ \(input, expected) ->
+explicit = parallel $ do
+  forM_ cases $ \(input, expected) -> do
+    describe "specific parser" $ do
       it (printf "correctly parses %s" (show input)) $ do
         let output = runParser msgParser input
         let result = fmap fst output
@@ -33,13 +43,19 @@ form = parallel $ do
         case rest of
           Just "" -> return ()
           _       -> error "parser did not consume all tokens"
-  describe "generic parser" $ do
-    forM_ cases $ \(input, expected) ->
+    describe "generic parser" $ do
       it (printf "correctly parses %s" (show input)) $ do
-      let output = genericParse input
-      output `shouldBe` Just (ParsedMsg expected)
+        let output = genericParse input
+        output `shouldBe` Just (ParsedMsg expected)
 
-spec :: Spec
-spec = do
-  form
+--applicative = parallel $ do
+--  describe "applicative" $ do
+--    it "generates correct messages" $ do
+--      let msgs = map uncurry (Msg
+--            <$> subjectCases
+--            <*> map fromIntegral clientIDCases
+--            <*> maybeify subjectCases)
+--            <*> payloadCases -- because byteCount and payload are in valid pairs we needed to uncurry this
+--      let proto = map buildProtoManually msgs
+--      map genericParse proto `shouldBe` map (Just . ParsedMsg) msgs
 

--- a/test/Unit/OkSpec.hs
+++ b/test/Unit/OkSpec.hs
@@ -2,29 +2,23 @@
 
 module OkSpec (spec) where
 
-import           Lib.Parser
+import           Control.Monad
+import qualified Data.ByteString as BS
 import           Parsers.Parsers
 import           Test.Hspec
+import           Text.Printf
 import           Types.Ok
 
 spec :: Spec
 spec = do
-  manual
+  cases
 
-manual :: Spec
-manual = parallel $ do
-  describe "specific parser" $ do
-    it "correctly parses +OK" $ do
-      let output = runParser okParser "+OK\r\n"
-      let result = fmap fst output
-      let rest = fmap snd output
-      case result of
-        Just (ParsedOk a) -> a `shouldBe` Ok
-        Nothing           -> error "parser did not return OK type"
-      case rest of
-        Just "" -> return ()
-        _       -> error "parser did not consume all tokens"
-  describe "specific parser" $ do
-    it "correctly parses +OK" $ do
-      let output = genericParse "+OK\r\n"
-      output `shouldBe` Just (ParsedOk Ok)
+explicitCases :: [(BS.ByteString, Ok)]
+explicitCases = [("+OK\r\n", Ok)]
+
+cases = parallel $ do
+  describe "generic parser" $ do
+      forM_ explicitCases $ \(input, want) ->
+        it (printf "correctly parses explicit case %s" (show input)) $ do
+          let output = genericParse input
+          output `shouldBe` Just (ParsedOk want)

--- a/test/Unit/ParserSpec.hs
+++ b/test/Unit/ParserSpec.hs
@@ -21,27 +21,27 @@ charCases = zip (map charToByteString [(minBound::Char)..(maxBound::Char)]) [(mi
 
 char = parallel $ do
   describe "generated" $ do
-   forM_ charCases $ \(input, expected) ->
-    describe (printf "char %s" (word8ToString expected)) $ do
-      it (printf "correctly parses %s" (show input)) $ do
-        let output = Parser.runParser (Parser.char expected) input
-        let result = fmap fst output
-        result `shouldBe` Just expected
-        let left = fmap snd output
-        left `shouldBe` Just ""
-      it "returns Nothing given empty string" $ do
-        let output = Parser.runParser (Parser.char expected) ""
-        let result = fmap fst output
-        result `shouldBe` Nothing
-        let left = fmap snd output
-        left `shouldBe` Nothing
-      forM_ (filterSameChar input charCases) $ \(sinput, _) ->
-        it (printf "returns Nothing given %s" (show sinput)) $ do
-          let output = Parser.runParser (Parser.char expected) sinput
-          let result = fmap fst output
-          result `shouldBe` Nothing
-          let left = fmap snd output
-          left `shouldBe` Nothing
+    forM_ charCases $ \(input, want) ->
+     describe (printf "char %s" (word8ToString want)) $ do
+       it (printf "correctly parses generated case %s" (show input)) $ do
+         let output = Parser.runParser (Parser.char want) input
+         let result = fmap fst output
+         result `shouldBe` Just want
+         let left = fmap snd output
+         left `shouldBe` Just ""
+       it "returns Nothing given empty string" $ do
+         let output = Parser.runParser (Parser.char want) ""
+         let result = fmap fst output
+         result `shouldBe` Nothing
+         let left = fmap snd output
+         left `shouldBe` Nothing
+       forM_ (filterSameChar input charCases) $ \(sinput, _) ->
+         it (printf "returns Nothing given %s" (show sinput)) $ do
+           let output = Parser.runParser (Parser.char want) sinput
+           let result = fmap fst output
+           result `shouldBe` Nothing
+           let left = fmap snd output
+           left `shouldBe` Nothing
 
 filterSameChar :: BS.ByteString -> [(BS.ByteString, W8.Word8)] -> [(BS.ByteString, W8.Word8)]
 filterSameChar i [] = []

--- a/test/Unit/ParserSpec.hs
+++ b/test/Unit/ParserSpec.hs
@@ -5,7 +5,6 @@ module ParserSpec (spec) where
 import           Control.Monad
 import qualified Data.ByteString       as BS
 import qualified Data.ByteString.Char8 as B
-import           Data.Char
 import qualified Data.Word8            as W8
 import qualified Lib.Parser            as Parser
 import           Test.Hspec

--- a/test/Unit/ParserSpec.hs
+++ b/test/Unit/ParserSpec.hs
@@ -21,6 +21,7 @@ charCases = zip (map charToByteString [(minBound::Char)..(maxBound::Char)]) [(mi
     charToByteString c = B.pack [c]
 
 char = parallel $ do
+  describe "generated" $ do
    forM_ charCases $ \(input, expected) ->
     describe (printf "char %s" (word8ToString expected)) $ do
       it (printf "correctly parses %s" (show input)) $ do

--- a/test/Unit/PongSpec.hs
+++ b/test/Unit/PongSpec.hs
@@ -2,33 +2,31 @@
 
 module PongSpec (spec) where
 
-import           Lib.Parser
+import           Control.Monad
+import qualified Data.ByteString           as BS
 import           Parsers.Parsers
 import           Test.Hspec
+import           Text.Printf
 import           Transformers.Transformers
 import           Types.Pong
 
 spec :: Spec
 spec = do
-  manual
+  cases
 
-manual :: Spec
-manual = parallel $ do
-  describe "specific parser" $ do
-    it "correctly parses PONG" $ do
-      let output = runParser pongParser "PONG\r\n"
-      let result = fmap fst output
-      let rest = fmap snd output
-      case result of
-        Just (ParsedPong a) -> a `shouldBe` Pong
-        Nothing             -> error "parser did not return PONG type"
-      case rest of
-        Just "" -> return ()
-        _       -> error "parser did not consume all tokens"
+explicitParserCases :: [(BS.ByteString, Pong)]
+explicitParserCases = [("PONG\r\n", Pong)]
+
+explicitTransformerCases :: [(Pong, BS.ByteString)]
+explicitTransformerCases = map (\(a,b) -> (b,a)) explicitParserCases
+
+cases = parallel $ do
   describe "generic parser" $ do
-    it "correctly parses PONG" $ do
-      let output = genericParse "PONG\r\n"
-      output `shouldBe` Just (ParsedPong Pong)
-  describe "transformer" $ do
-    it "correctly transforms to 'PONG'" $ do
-      transform Pong `shouldBe` "PONG\r\n"
+    forM_ explicitParserCases $ \(input, want) -> do
+      it (printf "correctly parses explicit case %s" (show input)) $ do
+        let output = genericParse input
+        output `shouldBe` Just (ParsedPong want)
+  describe "PONG transformer" $ do
+    forM_ explicitTransformerCases $ \(input, want) -> do
+      it (printf "correctly transforms %s" (show input)) $ do
+        transform input `shouldBe` want

--- a/test/Unit/PubSpec.hs
+++ b/test/Unit/PubSpec.hs
@@ -6,7 +6,6 @@ import           ASCII                     as A
 import           ASCII.Char                as AC
 import           Control.Monad
 import qualified Data.ByteString           as BS
-import           Data.Maybe
 import qualified Data.Text                 as T
 import           Data.Text.Encoding        (encodeUtf8)
 import           Fixtures

--- a/test/Unit/PubSpec.hs
+++ b/test/Unit/PubSpec.hs
@@ -2,8 +2,14 @@
 
 module PubSpec (spec) where
 
+import           ASCII                     as A
+import           ASCII.Char                as AC
 import           Control.Monad
-import           Data.ByteString
+import qualified Data.ByteString           as BS
+import           Data.Maybe
+import qualified Data.Text                 as T
+import           Data.Text.Encoding        (encodeUtf8)
+import           Fixtures
 import           Test.Hspec
 import           Text.Printf
 import           Transformers.Transformers
@@ -11,9 +17,10 @@ import           Types.Pub
 
 spec :: Spec
 spec = do
-  manual
+  explicit
+  generated
 
-cases :: [(Pub, ByteString, String)]
+cases :: [(Pub, BS.ByteString, String)]
 cases = [
   (Pub "FOO.BAR" Nothing Nothing, "PUB FOO.BAR 0\r\n", "without max messages"),
   (Pub "FOO.BAR" Nothing (Just "Some payload bits"), "PUB FOO.BAR 17\r\nSome payload bits\r\n", "with max messages"),
@@ -21,7 +28,37 @@ cases = [
   (Pub "FOO.BAR" (Just "FOO.BAR.REPLY") (Just "Some payload bits"), "PUB FOO.BAR FOO.BAR.REPLY 17\r\nSome payload bits\r\n", "with max messages")
   ]
 
-manual = parallel $ do
+explicit = parallel $ do
   forM_ cases $ \(input, expected, caseName) ->
     it (printf "correctly transforms %s" caseName) $ do
       transform input `shouldBe` expected
+
+generated = parallel $ do
+  describe "generated" $ do
+    forM_ subjectCases $ \subject -> do
+      forM_ (maybeify subjectCases) $ \replyTo -> do
+        forM_ maxPayloadCases $ \byteCount -> do
+          let payload = payloadGen byteCount
+          let output = foldr BS.append "" [
+                "PUB ",
+                subject,
+                " ",
+                collapseMaybeBS replyTo " ",
+                intToByteString byteCount,
+                "\r\n",
+                collapseMaybeBS payload "\r\n"
+                ]
+          it (printf "correctly transforms %s" (show output)) $ do
+            transform (Pub subject replyTo payload) `shouldBe` output
+
+infASCII = cycle AC.allCharacters
+
+payloadGen n
+  | n == 0 = Nothing
+  | n > 0 = Just . encodeUtf8 . T.pack . map A.charToUnicode $ take n infASCII
+
+collapseMaybeBS :: Maybe BS.ByteString -> BS.ByteString -> BS.ByteString
+collapseMaybeBS (Just a) sep = BS.append a sep
+collapseMaybeBS Nothing _    = ""
+
+intToByteString = encodeUtf8 . T.pack . show

--- a/test/Unit/PubSpec.hs
+++ b/test/Unit/PubSpec.hs
@@ -2,13 +2,8 @@
 
 module PubSpec (spec) where
 
-import           ASCII                     as A
-import           ASCII.Char                as AC
 import           Control.Monad
 import qualified Data.ByteString           as BS
-import qualified Data.Text                 as T
-import           Data.Text.Encoding        (encodeUtf8)
-import           Fixtures
 import           Test.Hspec
 import           Text.Printf
 import           Transformers.Transformers
@@ -17,7 +12,6 @@ import           Types.Pub
 spec :: Spec
 spec = do
   explicit
-  generated
 
 cases :: [(Pub, BS.ByteString, String)]
 cases = [
@@ -32,32 +26,3 @@ explicit = parallel $ do
     it (printf "correctly transforms %s" caseName) $ do
       transform input `shouldBe` expected
 
-generated = parallel $ do
-  describe "generated" $ do
-    forM_ subjectCases $ \subject -> do
-      forM_ (maybeify subjectCases) $ \replyTo -> do
-        forM_ maxPayloadCases $ \byteCount -> do
-          let payload = payloadGen byteCount
-          let output = foldr BS.append "" [
-                "PUB ",
-                subject,
-                " ",
-                collapseMaybeBS replyTo " ",
-                intToByteString byteCount,
-                "\r\n",
-                collapseMaybeBS payload "\r\n"
-                ]
-          it (printf "correctly transforms %s" (show output)) $ do
-            transform (Pub subject replyTo payload) `shouldBe` output
-
-infASCII = cycle AC.allCharacters
-
-payloadGen n
-  | n == 0 = Nothing
-  | n > 0 = Just . encodeUtf8 . T.pack . map A.charToUnicode $ take n infASCII
-
-collapseMaybeBS :: Maybe BS.ByteString -> BS.ByteString -> BS.ByteString
-collapseMaybeBS (Just a) sep = BS.append a sep
-collapseMaybeBS Nothing _    = ""
-
-intToByteString = encodeUtf8 . T.pack . show

--- a/test/Unit/PubSpec.hs
+++ b/test/Unit/PubSpec.hs
@@ -11,18 +11,19 @@ import           Types.Pub
 
 spec :: Spec
 spec = do
-  explicit
+  cases
 
-cases :: [(Pub, BS.ByteString, String)]
-cases = [
-  (Pub "FOO.BAR" Nothing Nothing, "PUB FOO.BAR 0\r\n", "without max messages"),
-  (Pub "FOO.BAR" Nothing (Just "Some payload bits"), "PUB FOO.BAR 17\r\nSome payload bits\r\n", "with max messages"),
-  (Pub "FOO.BAR" (Just "FOO.BAR.REPLY") Nothing, "PUB FOO.BAR FOO.BAR.REPLY 0\r\n", "with max messages"),
-  (Pub "FOO.BAR" (Just "FOO.BAR.REPLY") (Just "Some payload bits"), "PUB FOO.BAR FOO.BAR.REPLY 17\r\nSome payload bits\r\n", "with max messages")
+explicitCases :: [(Pub, BS.ByteString)]
+explicitCases = [
+  (Pub "FOO.BAR" Nothing Nothing, "PUB FOO.BAR 0\r\n"),
+  (Pub "FOO.BAR" Nothing (Just "Some payload bits"), "PUB FOO.BAR 17\r\nSome payload bits\r\n"),
+  (Pub "FOO.BAR" (Just "FOO.BAR.REPLY") Nothing, "PUB FOO.BAR FOO.BAR.REPLY 0\r\n"),
+  (Pub "FOO.BAR" (Just "FOO.BAR.REPLY") (Just "Some payload bits"), "PUB FOO.BAR FOO.BAR.REPLY 17\r\nSome payload bits\r\n")
   ]
 
-explicit = parallel $ do
-  forM_ cases $ \(input, expected, caseName) ->
-    it (printf "correctly transforms %s" caseName) $ do
-      transform input `shouldBe` expected
+cases = parallel $ do
+  describe "PUB transformer" $ do
+    forM_ explicitCases $ \(input, want) ->
+      it (printf "correctly transforms %s" (show input)) $ do
+        transform input `shouldBe` want
 

--- a/test/Unit/SubSpec.hs
+++ b/test/Unit/SubSpec.hs
@@ -11,15 +11,16 @@ import           Types.Sub
 
 spec :: Spec
 spec = do
-  manual
+  cases
 
-cases :: [(Sub, ByteString, String)]
-cases = [
-  (Sub "SOME.SUBJ" Nothing "uuid", "SUB SOME.SUBJ uuid", "without queue group"),
-  (Sub "SOME.SUBJ" (Just "QUEUE.GROUP.A") "uuid", "SUB SOME.SUBJ QUEUE.GROUP.A uuid", "with queue group")
+explicitCases :: [(Sub, ByteString)]
+explicitCases = [
+  (Sub "SOME.SUBJ" Nothing "uuid", "SUB SOME.SUBJ uuid"),
+  (Sub "SOME.SUBJ" (Just "QUEUE.GROUP.A") "uuid", "SUB SOME.SUBJ QUEUE.GROUP.A uuid")
   ]
 
-manual = parallel $ do
-  forM_ cases $ \(input, expected, caseName) ->
-    it (printf "correctly transforms %s" caseName) $ do
-      transform input `shouldBe` expected
+cases = parallel $ do
+  describe "SUB transformer" $ do
+    forM_ explicitCases $ \(input, want) ->
+      it (printf "correctly transforms %s" (show input)) $ do
+        transform input `shouldBe` want

--- a/test/Unit/UnsubSpec.hs
+++ b/test/Unit/UnsubSpec.hs
@@ -11,15 +11,16 @@ import           Types.Unsub
 
 spec :: Spec
 spec = do
-  manual
+  cases
 
-cases :: [(Unsub, ByteString, String)]
-cases = [
-  (Unsub "uuid" Nothing, "UNSUB uuid", "without max messages"),
-  (Unsub "uuid" (Just 10), "UNSUB uuid 10", "with max messages")
+explicitCases :: [(Unsub, ByteString)]
+explicitCases = [
+  (Unsub "uuid" Nothing, "UNSUB uuid"),
+  (Unsub "uuid" (Just 10), "UNSUB uuid 10")
   ]
 
-manual = parallel $ do
-  forM_ cases $ \(input, expected, caseName) ->
-    it (printf "correctly transforms %s" caseName) $ do
-      transform input `shouldBe` expected
+cases = parallel $ do
+  describe "UNSUB transformer" $ do
+    forM_ explicitCases $ \(input, want) ->
+      it (printf "correctly transforms %s" (show input)) $ do
+        transform input `shouldBe` want


### PR DESCRIPTION
- [x]  Generates test cases for parsers
- [x] Adds more cases into explicit tests where necessary. 
- [x]  Makes a common standard for these tests cases - [(input, want)]
- [x]  Cleans up the hspec tagging to be consistent

for parsers [(ByteString, StructuredValue)]
for transformers [(StructuredValue, ByteString)]

that way the case generation/definition doesn't have to be in the test handler.

Closes #67 
Closes #34 
