### PR TITLE
chore: release 1.0.0.0

### DIFF
--- a/natskell.cabal
+++ b/natskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   natskell
-version:                0.4.0.0
+version:                1.0.0.0
 synopsis:               A NATS client library written in Haskell
 tested-with:
   GHC ==8.8,


### PR DESCRIPTION
Bumps the natskell package version from 0.4.0.0 to 1.0.0.0 after the stabilized core NATS and JetStream API work in #181.