### PR TITLE
Release 1.0.0.1

### DIFF
--- a/natskell.cabal
+++ b/natskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   natskell
-version:                1.0.0.0
+version:                1.0.0.1
 synopsis:               A NATS client library written in Haskell
 tested-with:
   GHC ==8.8,


### PR DESCRIPTION
Bumps the natskell package version to 1.0.0.1 after the public API reorganization merged in #183.\n\nNo behavior changes in this PR. Formatting, HLint, and nix flake check pass locally.