### PR TITLE
feat: add confirmed JetStream dispositions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,24 @@ The focused contracts live under `JetStream.API.Stream`,
 `JetStream.API.Management`. Every network operation has a final request-options
 argument, so future call options can be added without changing its type.
 
+The existing `ack`, `nak`, `inProgress`, and `term` dispositions are
+asynchronous when their request-options list is empty. Supplying a request
+option to one of these operations or to `nakWithDelay` asks JetStream to confirm
+the disposition; `ackSync` always requests confirmation. `termSync` provides
+the same guarantee for terminal dispositions as a natskell convenience.
+Delayed redelivery requires NATS Server 2.7.1 or newer and uses a validated,
+whole-nanosecond duration:
+
+```haskell
+case JetStream.nakDelay 30 of
+  Nothing -> pure ()
+  Just delay ->
+    JetStream.nakWithDelay (JetStream.messages jetStream) message delay []
+```
+
+`nakDelay` rejects durations below one nanosecond and values outside the
+JetStream signed 64-bit nanosecond range.
+
 ### Exit handling
 
 ```haskell

--- a/jetstream/JetStream/Message.hs
+++ b/jetstream/JetStream/Message.hs
@@ -49,12 +49,15 @@ import           JetStream.Options
     ( JetStreamContext (..)
     , requestTimeoutMicros
     )
+import           JetStream.Protocol.Headers (statusError)
+import           JetStream.Protocol.Request (requestMsg)
 import qualified JetStream.Protocol.Subject as Subject
 import           JetStream.Types
     ( AckPolicy (AckNone)
     , ConsumerName
     , DeliverPolicy (DeliverByStartSequence)
     , JetStreamRequestOption
+    , Payload
     , StreamName
     , Subject
     )
@@ -70,10 +73,14 @@ messageAPI context consumerAPI =
         consumePushMessages context deliverSubject (pushConsumeConfig options) handler
     , createOrderedConsumer = \stream options requestOptions ->
         createOrderedConsumerHandle context consumerAPI stream (orderedConsumerConfig options) requestOptions
-    , ack = \message _ -> ackMessage (contextClient context) message
-    , nak = \message _ -> nakMessage (contextClient context) message
-    , inProgress = \message _ -> inProgressMessage (contextClient context) message
-    , term = \message _ -> termMessage (contextClient context) message
+    , ack = sendDisposition context ConfirmWhenRequested (ackPayload Ack)
+    , ackSync = sendDisposition context ConfirmAlways (ackPayload Ack)
+    , nak = sendDisposition context ConfirmWhenRequested (ackPayload Nak)
+    , nakWithDelay = \message delay ->
+        sendDisposition context ConfirmWhenRequested (nakDelayPayload delay) message
+    , inProgress = sendDisposition context ConfirmWhenRequested (ackPayload InProgress)
+    , term = sendDisposition context ConfirmWhenRequested (ackPayload Term)
+    , termSync = sendDisposition context ConfirmAlways (ackPayload Term)
     }
 
 consumePushMessages
@@ -373,6 +380,45 @@ publishAck natsClient verb message =
       pure (Left JetStreamNoReply)
     Just reply ->
       mapNatsResult <$> Nats.publish natsClient reply (ackPayload verb) []
+
+data ConfirmationMode = ConfirmWhenRequested | ConfirmAlways
+
+sendDisposition
+  :: JetStreamContext
+  -> ConfirmationMode
+  -> Payload
+  -> Message
+  -> [JetStreamRequestOption]
+  -> IO (Either JetStreamError ())
+sendDisposition context confirmationMode body message requestOptions =
+  case messageReplyTo message of
+    Nothing ->
+      pure (Left JetStreamNoReply)
+    Just reply
+      | confirmationRequired confirmationMode requestOptions ->
+          confirmDisposition context reply body requestOptions
+      | otherwise ->
+          mapNatsResult <$> Nats.publish (contextClient context) reply body []
+
+confirmDisposition
+  :: JetStreamContext
+  -> Subject
+  -> Payload
+  -> [JetStreamRequestOption]
+  -> IO (Either JetStreamError ())
+confirmDisposition context reply body requestOptions = do
+  response <- requestMsg context reply body [] requestOptions
+  pure $ do
+    message <- response
+    case statusError message of
+      Just err ->
+        Left err
+      Nothing ->
+        Right ()
+
+confirmationRequired :: ConfirmationMode -> [JetStreamRequestOption] -> Bool
+confirmationRequired ConfirmAlways _ = True
+confirmationRequired ConfirmWhenRequested requestOptions = not (null requestOptions)
 
 mapNatsResult :: Either Nats.NatsError () -> Either JetStreamError ()
 mapNatsResult =

--- a/jetstream/JetStream/Message/API.hs
+++ b/jetstream/JetStream/Message/API.hs
@@ -4,9 +4,14 @@ module JetStream.Message.API
   , consumePush
   , createOrderedConsumer
   , ack
+  , ackSync
   , nak
+  , nakWithDelay
+  , NakDelay
+  , nakDelay
   , inProgress
   , term
+  , termSync
   , FetchOption
   , FetchWait (..)
   , Headers
@@ -56,6 +61,7 @@ import           JetStream.Message.Types
     , Message (..)
     , MessageAPI
     , MessageMetadata
+    , NakDelay
     , OrderedConsumer
     , OrderedConsumerOption
     , PullResponse
@@ -63,6 +69,7 @@ import           JetStream.Message.Types
     , PushConsumeOption
     , PushSubscription
     , ack
+    , ackSync
     , consumePush
     , createOrderedConsumer
     , fetch
@@ -83,12 +90,15 @@ import           JetStream.Message.Types
     , messageStatus
     , messageSubject
     , nak
+    , nakDelay
+    , nakWithDelay
     , orderedConsumerInfo
     , pullResponseMessages
     , pullResponseStatus
     , stopOrderedConsumer
     , stopPushSubscription
     , term
+    , termSync
     , withFetchBatch
     , withFetchWait
     , withOrderedConsumerDeliverPolicy

--- a/jetstream/JetStream/Message/Types.hs
+++ b/jetstream/JetStream/Message/Types.hs
@@ -3,6 +3,7 @@
 module JetStream.Message.Types
   ( MessageAPI (..)
   , AckVerb (..)
+  , NakDelay (..)
   , FetchOption
   , FetchWait (..)
   , Headers
@@ -26,6 +27,8 @@ module JetStream.Message.Types
   , isStatusMessage
   , messageMetadata
   , nakPayload
+  , nakDelay
+  , nakDelayPayload
   , orderedConsumerConfig
   , pullRequestPayload
   , pushConsumeConfig
@@ -46,6 +49,7 @@ import           Data.ByteString          (ByteString)
 import qualified Data.ByteString          as BS
 import qualified Data.ByteString.Char8    as BC
 import           Data.Char                (isDigit, toLower)
+import           Data.Int                 (Int64)
 import           Data.Maybe               (isJust)
 import           Data.Time.Clock          (NominalDiffTime, UTCTime)
 import qualified Data.Time.Clock.POSIX    as Time
@@ -72,9 +76,12 @@ data MessageAPI = MessageAPI
                     , consumePush :: Subject -> [PushConsumeOption] -> [JetStreamRequestOption] -> (Message -> IO ()) -> IO (Either JetStreamError PushSubscription)
                     , createOrderedConsumer :: StreamName -> [OrderedConsumerOption] -> [JetStreamRequestOption] -> IO (Either JetStreamError OrderedConsumer)
                     , ack :: Message -> [JetStreamRequestOption] -> IO (Either JetStreamError ())
+                    , ackSync :: Message -> [JetStreamRequestOption] -> IO (Either JetStreamError ())
                     , nak :: Message -> [JetStreamRequestOption] -> IO (Either JetStreamError ())
+                    , nakWithDelay :: Message -> NakDelay -> [JetStreamRequestOption] -> IO (Either JetStreamError ())
                     , inProgress :: Message -> [JetStreamRequestOption] -> IO (Either JetStreamError ())
                     , term :: Message -> [JetStreamRequestOption] -> IO (Either JetStreamError ())
+                    , termSync :: Message -> [JetStreamRequestOption] -> IO (Either JetStreamError ())
                     }
 
 data PullRequest = PullRequest
@@ -213,6 +220,21 @@ data PullStatus = PullNoMessages (Maybe ByteString)
 data AckVerb = Ack | Nak | InProgress | Term
   deriving (Eq, Show)
 
+-- | A positive, whole-nanosecond JetStream redelivery delay.
+newtype NakDelay = NakDelay Int64
+  deriving (Eq, Show)
+
+-- | Build a delayed-NAK duration. Durations below one nanosecond, negative
+-- durations, and values outside the JetStream signed 64-bit wire range are
+-- rejected. Sub-nanosecond precision is rounded down.
+nakDelay :: NominalDiffTime -> Maybe NakDelay
+nakDelay duration
+  | nanoseconds < 1 = Nothing
+  | nanoseconds > toInteger (maxBound :: Int64) = Nothing
+  | otherwise = Just (NakDelay (fromInteger nanoseconds))
+  where
+    nanoseconds = floor (toRational duration * 1000000000)
+
 ackPayload :: AckVerb -> Payload
 ackPayload Ack        = "+ACK"
 ackPayload Nak        = "-NAK"
@@ -221,6 +243,15 @@ ackPayload Term       = "+TERM"
 
 nakPayload :: Payload
 nakPayload = ackPayload Nak
+
+nakDelayPayload :: NakDelay -> Payload
+nakDelayPayload (NakDelay nanoseconds) =
+  BS.concat
+    [ nakPayload
+    , " {\"delay\":"
+    , BC.pack (show nanoseconds)
+    , "}"
+    ]
 
 inProgressPayload :: Payload
 inProgressPayload = ackPayload InProgress

--- a/system-tests/test/System/JetStreamSpec.hs
+++ b/system-tests/test/System/JetStreamSpec.hs
@@ -57,6 +57,9 @@ spec =
       jetStreamSystemTest "1ff65118-b330-4b06-8592-8d331c0d8f6d"
         "redelivers after NAK"
         nakRedeliveryTest
+      jetStreamSystemTest "03daa560-c2bc-426f-b733-f2dfc5927cf5"
+        "honours delayed NAK redelivery"
+        delayedNakRedeliveryTest
       jetStreamSystemTest "227ca150-9ecf-4541-a627-a3b45ab3b778"
         "does not redeliver after TERM"
         termStopsRedeliveryTest
@@ -162,11 +165,14 @@ durablePullConsumerTest jetStream = do
   firstFetch <- expectRight "first fetch" $
     JetStream.fetch (messages jetStream) streamName durableName fetchBatch []
   case JetStream.pullResponseMessages firstFetch of
-    messages'@[_, _] -> do
+    messages'@[firstMessage, secondMessage] -> do
       fmap JetStream.messageSubject messages' `shouldBe` [subjectName, subjectName]
       fmap JetStream.messagePayload messages' `shouldBe` payloadBodies
-      acknowledgements <- mapM (\message -> JetStream.ack (messages jetStream) message []) messages'
-      acknowledgements `shouldBe` [Right (), Right ()]
+      JetStream.ackSync (messages jetStream) firstMessage []
+        `shouldReturn` Right ()
+      JetStream.ack (messages jetStream) secondMessage
+        [JetStream.withRequestTimeout 1]
+        `shouldReturn` Right ()
     messages' ->
       expectationFailure ("expected two JetStream messages, got " ++ show (length messages'))
   JetStream.pullResponseStatus firstFetch `shouldBe` Nothing
@@ -295,6 +301,30 @@ nakRedeliveryTest jetStream = do
   JetStream.messagePayload secondMessage `shouldBe` "redeliver"
   ackOrFail jetStream secondMessage
 
+delayedNakRedeliveryTest :: JetStream -> IO ()
+delayedNakRedeliveryTest jetStream = do
+  let stream = "NATSKELL_JS_DELAYED_NAK"
+      subject = "NATSKELL.JS.DELAYED_NAK"
+      durable = "DELAYED_NAK_WORKER"
+      Just delay = JetStream.nakDelay 0.4
+  createStreamOrFail jetStream stream [subject] streamOptions
+  createDurableConsumerOrFail jetStream stream durable $
+    pullConsumerOptions durable []
+  publishPayload jetStream subject "redeliver-later"
+  firstMessage <- fetchOneMessage jetStream stream durable
+  JetStream.nakWithDelay (messages jetStream) firstMessage delay []
+    `shouldReturn` Right ()
+
+  early <- expectRight "fetch before delayed NAK expires" $
+    JetStream.fetch (messages jetStream) stream durable shortFetch []
+  JetStream.pullResponseMessages early `shouldBe` []
+  expectNoMessages early
+
+  threadDelay 500000
+  redelivered <- fetchOneMessage jetStream stream durable
+  JetStream.messagePayload redelivered `shouldBe` "redeliver-later"
+  ackOrFail jetStream redelivered
+
 termStopsRedeliveryTest :: JetStream -> IO ()
 termStopsRedeliveryTest jetStream = do
   let stream = "NATSKELL_JS_TERM"
@@ -305,7 +335,7 @@ termStopsRedeliveryTest jetStream = do
     pullConsumerOptions durable []
   publishPayload jetStream subject "stop"
   message <- fetchOneMessage jetStream stream durable
-  JetStream.term (messages jetStream) message [] `shouldReturn` Right ()
+  JetStream.termSync (messages jetStream) message [] `shouldReturn` Right ()
   empty <- expectRight "fetch after term" $
     JetStream.fetch (messages jetStream) stream durable shortFetch []
   JetStream.pullResponseMessages empty `shouldBe` []

--- a/test/PublicAPI/Main.hs
+++ b/test/PublicAPI/Main.hs
@@ -141,7 +141,14 @@ messageOperations
 messageOperations messageAPI message = do
   JetStreamMessage.messageMetadata message `seq` pure ()
   _ <- JetStreamMessage.ack messageAPI message []
+  _ <- JetStreamMessage.ackSync messageAPI message []
   _ <- JetStreamMessage.nak messageAPI message []
+  case JetStreamMessage.nakDelay 1 of
+    Nothing -> pure ()
+    Just delay -> do
+      _ <- JetStreamMessage.nakWithDelay messageAPI message delay []
+      pure ()
+  _ <- JetStreamMessage.termSync messageAPI message []
   pure ()
 
 inspectJetStreamApiError :: JetStream.JetStreamApiError -> IO ()

--- a/test/Unit/JetStream/MessageSpec.hs
+++ b/test/Unit/JetStream/MessageSpec.hs
@@ -335,6 +335,7 @@ ackFakeClient publishCalls requestCalls response =
     , Nats.newInbox = pure "_INBOX.ack"
     , Nats.ping = \_ -> pure (Right ())
     , Nats.flush = \_ -> pure (Right ())
+    , Nats.connectionState = pure Nats.ConnectionConnected
     , Nats.reset = \_ -> pure ()
     , Nats.close = \_ -> pure ()
     }

--- a/test/Unit/JetStream/MessageSpec.hs
+++ b/test/Unit/JetStream/MessageSpec.hs
@@ -3,11 +3,14 @@
 module JetStream.MessageSpec (spec) where
 
 import qualified Client.API              as Nats
+import           Data.Int                (Int64)
 import           Data.IORef
+import           Data.Ratio              ((%))
 import           JetStream.Error         (JetStreamError (..))
-import           JetStream.Message       (fetchMessages)
+import           JetStream.Message       (fetchMessages, messageAPI)
 import           JetStream.Message.Types
 import           JetStream.Options       (newJetStreamContext)
+import           JetStream.Types         (withRequestTimeout)
 import           Publish                 (defaultPublishConfig)
 import           Publish.Config          (publishReplyTo)
 import           Test.Hspec
@@ -38,6 +41,112 @@ spec = do
       nakPayload `shouldBe` "-NAK"
       inProgressPayload `shouldBe` "+WPI"
       termPayload `shouldBe` "+TERM"
+
+    it "encodes delayed NAKs as exact integer nanoseconds" $ do
+      fmap nakDelayPayload (nakDelay 1.234567891234)
+        `shouldBe` Just "-NAK {\"delay\":1234567891}"
+
+    it "rejects delays shorter than one nanosecond" $ do
+      nakDelay 0 `shouldBe` Nothing
+      nakDelay 0.000000000999 `shouldBe` Nothing
+      nakDelay (-1) `shouldBe` Nothing
+
+    it "accepts the exact signed 64-bit nanosecond boundaries" $ do
+      let oneNanosecond = fromRational (1 % 1000000000)
+          maxNanoseconds = toInteger (maxBound :: Int64)
+          maxDelay = fromRational (maxNanoseconds % 1000000000)
+          overflowDelay = fromRational ((maxNanoseconds + 1) % 1000000000)
+      fmap nakDelayPayload (nakDelay oneNanosecond)
+        `shouldBe` Just "-NAK {\"delay\":1}"
+      fmap nakDelayPayload (nakDelay maxDelay)
+        `shouldBe` Just "-NAK {\"delay\":9223372036854775807}"
+      nakDelay overflowDelay `shouldBe` Nothing
+
+  describe "message dispositions" $ do
+    it "keeps empty-option acknowledgements asynchronous" $ do
+      publishes <- newIORef []
+      requests <- newIORef []
+      let api = messageAPI
+            (newJetStreamContext (ackFakeClient publishes requests ackReply) [])
+            (error "unused consumer API")
+
+      ack api ackMessage [] `shouldReturn` Right ()
+      readIORef publishes `shouldReturn` [(ackSubject, "+ACK")]
+      readIORef requests `shouldReturn` []
+
+    it "uses request-reply when acknowledgement request options are supplied" $ do
+      publishes <- newIORef []
+      requests <- newIORef []
+      let api = messageAPI
+            (newJetStreamContext (ackFakeClient publishes requests ackReply) [])
+            (error "unused consumer API")
+
+      ack api ackMessage [withRequestTimeout 0.25] `shouldReturn` Right ()
+      readIORef publishes `shouldReturn` []
+      readIORef requests `shouldReturn` [(ackSubject, "+ACK")]
+
+    it "always confirms ackSync and termSync" $ do
+      publishes <- newIORef []
+      requests <- newIORef []
+      let api = messageAPI
+            (newJetStreamContext (ackFakeClient publishes requests ackReply) [])
+            (error "unused consumer API")
+
+      ackSync api ackMessage [] `shouldReturn` Right ()
+      termSync api ackMessage [] `shouldReturn` Right ()
+      readIORef publishes `shouldReturn` []
+      readIORef requests `shouldReturn`
+        [ (ackSubject, "+ACK")
+        , (ackSubject, "+TERM")
+        ]
+
+    it "sends delayed NAKs with the selected confirmation mode" $ do
+      publishes <- newIORef []
+      requests <- newIORef []
+      let api = messageAPI
+            (newJetStreamContext (ackFakeClient publishes requests ackReply) [])
+            (error "unused consumer API")
+          Just delay = nakDelay 2.5
+
+      nakWithDelay api ackMessage delay [] `shouldReturn` Right ()
+      nakWithDelay api ackMessage delay [withRequestTimeout 0.25]
+        `shouldReturn` Right ()
+      readIORef publishes `shouldReturn`
+        [(ackSubject, "-NAK {\"delay\":2500000000}")]
+      readIORef requests `shouldReturn`
+        [(ackSubject, "-NAK {\"delay\":2500000000}")]
+
+    it "maps confirmed acknowledgement timeouts" $ do
+      publishes <- newIORef []
+      requests <- newIORef []
+      let api = messageAPI
+            (newJetStreamContext
+              (ackFakeClient publishes requests (Left Nats.NatsRequestTimedOut))
+              [])
+            (error "unused consumer API")
+
+      ackSync api ackMessage [] `shouldReturn` Left JetStreamTimeout
+
+    it "maps confirmed acknowledgement status errors" $ do
+      publishes <- newIORef []
+      requests <- newIORef []
+      let response = Right (ackReplyMessage "" (Just [("Status", "409"), ("Description", "consumer deleted")]))
+          api = messageAPI
+            (newJetStreamContext (ackFakeClient publishes requests response) [])
+            (error "unused consumer API")
+
+      termSync api ackMessage []
+        `shouldReturn` Left (JetStreamStatusError 409 (Just "consumer deleted"))
+
+    it "accepts confirmed acknowledgement reply payloads" $ do
+      publishes <- newIORef []
+      requests <- newIORef []
+      let response = Right (ackReplyMessage "server metadata" Nothing)
+          api = messageAPI
+            (newJetStreamContext (ackFakeClient publishes requests response) [])
+            (error "unused consumer API")
+
+      ackSync api ackMessage [] `shouldReturn` Right ()
 
   describe "message metadata" $ do
     it "parses v1 JetStream ack reply subjects" $ do
@@ -180,6 +289,48 @@ silentFakeClient publishCalls unsubscribeCalls =
         modifyIORef' unsubscribeCalls (++ [sid])
         pure (Right ())
     , Nats.newInbox = pure "_INBOX.timeout"
+    , Nats.ping = \_ -> pure (Right ())
+    , Nats.flush = \_ -> pure (Right ())
+    , Nats.reset = \_ -> pure ()
+    , Nats.close = \_ -> pure ()
+    }
+
+ackSubject :: Subject
+ackSubject = "$JS.ACK.ORDERS.WORKER.1.1.1"
+
+ackMessage :: Message
+ackMessage = Message "ORDERS.created" "payload" Nothing (Just ackSubject) Nothing
+
+ackReply :: Either Nats.NatsError Nats.MsgView
+ackReply = Right (ackReplyMessage "" Nothing)
+
+ackReplyMessage :: Payload -> Maybe Nats.Headers -> Nats.Message
+ackReplyMessage body responseHeaders =
+  Nats.Message
+    { Nats.subject = "_INBOX.ack"
+    , Nats.sid = "sid-ack"
+    , Nats.replyTo = Nothing
+    , Nats.payload = body
+    , Nats.headers = responseHeaders
+    }
+
+ackFakeClient
+  :: IORef [(Subject, Payload)]
+  -> IORef [(Subject, Payload)]
+  -> Either Nats.NatsError Nats.MsgView
+  -> Nats.Client
+ackFakeClient publishCalls requestCalls response =
+  Nats.Client
+    { Nats.publish = \subject body _ -> do
+        modifyIORef' publishCalls (++ [(subject, body)])
+        pure (Right ())
+    , Nats.subscribe = \_ _ _ -> pure (Right (Nats.Subscription "sid-ack"))
+    , Nats.subscribeOnce = \_ _ _ -> pure (Right (Nats.Subscription "sid-ack-once"))
+    , Nats.request = \subject body _ -> do
+        modifyIORef' requestCalls (++ [(subject, body)])
+        pure response
+    , Nats.unsubscribe = \_ _ -> pure (Right ())
+    , Nats.newInbox = pure "_INBOX.ack"
     , Nats.ping = \_ -> pure (Right ())
     , Nats.flush = \_ -> pure (Right ())
     , Nats.reset = \_ -> pure ()


### PR DESCRIPTION
## Summary

- add confirmed ACK and TERM operations
- add validated delayed NAK support with exact nanosecond encoding
- preserve asynchronous behavior for existing empty-option disposition calls
- allow request options to opt existing dispositions into confirmation

## Verification

- `nix flake check`
- unit suite: 161,133 examples
- public API compile test
- real JetStream confirmed ACK, confirmed TERM, and delayed NAK tests
- Stylish Haskell and HLint

## Compatibility

Additive public API only. Existing disposition calls with `[]` remain fire-and-forget.
