### PR TITLE
feat: add JetStream resource limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,25 @@ The focused contracts live under `JetStream.API.Stream`,
 `JetStream.API.Management`. Every network operation has a final request-options
 argument, so future call options can be added without changing its type.
 
+Stream configuration supports a per-message encoded-size limit with
+`withMaxMessageSize`; the limit includes headers as well as payload bytes, and
+`-1` means unlimited.
+
+On NATS Server 2.7.1 or later, `withConsumerBackoff` configures redelivery after
+acknowledgment timeouts. It does not affect explicit NAK redelivery. The first
+delay overrides `AckWait`, later entries apply to successive redeliveries, and
+the final entry repeats after the schedule is exhausted. A non-empty schedule
+cannot be longer than a positive `MaxDeliver`. Durations are converted with
+exact arithmetic and floored to whole nanoseconds, so a non-negative duration
+below one nanosecond becomes zero; the wire values must fit signed 64-bit
+nanoseconds.
+
+`withConsumerMaxRequestBatch` caps pull-request batch size on NATS Server 2.7.0
+or later and is only meaningful for pull consumers. Empty backoff and a zero
+batch limit leave their server settings unset. Stream and consumer info expose
+effective values through `streamConfigMaxMessageSize`, `consumerConfigBackoff`,
+and `consumerConfigMaxRequestBatch`.
+
 ### Exit handling
 
 ```haskell

--- a/jetstream/JetStream/Consumer.hs
+++ b/jetstream/JetStream/Consumer.hs
@@ -19,6 +19,7 @@ import           JetStream.Consumer.Types
     , consumerNamesRequest
     , consumerPauseRequest
     , consumerResetRequest
+    , validateConsumerConfigRequest
     )
 import           JetStream.Error
     ( JetStreamError (JetStreamDecodeError)
@@ -93,11 +94,15 @@ consumerRequest context stream action target kind options =
   case consumerSubject context stream action target of
     Left err ->
       Left err
-    Right subject ->
-      Right
+    Right subject -> do
+      let config =
+            applyConsumerTarget target . applyConsumerKind kind $
+              consumerConfigRequest options
+      validateConsumerConfigRequest config
+      pure
         ( subject
         , actionValue
-        , applyConsumerTarget target . applyConsumerKind kind $ consumerConfigRequest options
+        , config
         )
   where
     actionValue =

--- a/jetstream/JetStream/Consumer/API.hs
+++ b/jetstream/JetStream/Consumer/API.hs
@@ -31,6 +31,8 @@ module JetStream.Consumer.API
   , consumerConfigMaxDeliver
   , consumerConfigMaxWaiting
   , consumerConfigMaxAckPending
+  , consumerConfigBackoff
+  , consumerConfigMaxRequestBatch
   , consumerConfigInactiveThreshold
   , consumerConfigIdleHeartbeat
   , consumerConfigHeadersOnly
@@ -80,6 +82,7 @@ module JetStream.Consumer.API
   , ReplayPolicy (..)
   , withConsumerAckPolicy
   , withConsumerAckWait
+  , withConsumerBackoff
   , withConsumerDescription
   , withConsumerDeliverGroup
   , withConsumerDeliverPolicy
@@ -89,6 +92,7 @@ module JetStream.Consumer.API
   , withConsumerInactiveThreshold
   , withConsumerListOffset
   , withConsumerMaxAckPending
+  , withConsumerMaxRequestBatch
   , withConsumerMaxDeliver
   , withConsumerMaxWaiting
   , withConsumerMemoryStorage

--- a/jetstream/JetStream/Consumer/Types.hs
+++ b/jetstream/JetStream/Consumer/Types.hs
@@ -25,6 +25,7 @@ module JetStream.Consumer.Types
   , applyConsumerKind
   , applyConsumerTarget
   , consumerConfigRequest
+  , validateConsumerConfigRequest
   , consumerActionValue
   , consumerListRequest
   , consumerNamesRequest
@@ -32,6 +33,7 @@ module JetStream.Consumer.Types
   , consumerResetRequest
   , withConsumerAckPolicy
   , withConsumerAckWait
+  , withConsumerBackoff
   , withConsumerDescription
   , withConsumerDeliverGroup
   , withConsumerDurableName
@@ -42,6 +44,7 @@ module JetStream.Consumer.Types
   , withConsumerInactiveThreshold
   , withConsumerListOffset
   , withConsumerMaxAckPending
+  , withConsumerMaxRequestBatch
   , withConsumerMaxDeliver
   , withConsumerMaxWaiting
   , withConsumerMemoryStorage
@@ -55,11 +58,12 @@ module JetStream.Consumer.Types
 import           Data.Aeson
 import           Data.Aeson.Types (Pair, Parser)
 import qualified Data.ByteString  as BS
+import           Data.Int         (Int64)
 import           Data.Maybe       (catMaybes)
 import qualified Data.Text        as T
 import           Data.Time.Clock  (NominalDiffTime, UTCTime)
 import           Data.Word        (Word64)
-import           JetStream.Error  (JetStreamError)
+import           JetStream.Error  (JetStreamError (JetStreamDecodeError))
 import           JetStream.Types
     ( AckPolicy (..)
     , CallOption
@@ -72,6 +76,7 @@ import           JetStream.Types
     , applyCallOptions
     , byteStringToJSON
     , diffTimeNanosToJSON
+    , diffTimeToNanoseconds
     , parseByteString
     )
 
@@ -109,6 +114,8 @@ data ConsumerConfigRequest = ConsumerConfigRequest
                                , consumerConfigRequestMaxDeliver :: Maybe Int
                                , consumerConfigRequestMaxWaiting :: Maybe Int
                                , consumerConfigRequestMaxAckPending :: Maybe Int
+                               , consumerConfigRequestBackoff :: Maybe [NominalDiffTime]
+                               , consumerConfigRequestMaxRequestBatch :: Maybe Int
                                , consumerConfigRequestInactiveThreshold :: Maybe NominalDiffTime
                                , consumerConfigRequestIdleHeartbeat :: Maybe NominalDiffTime
                                , consumerConfigRequestHeadersOnly :: Maybe Bool
@@ -156,12 +163,50 @@ emptyConsumerConfigRequest =
     , consumerConfigRequestMaxDeliver = Nothing
     , consumerConfigRequestMaxWaiting = Nothing
     , consumerConfigRequestMaxAckPending = Nothing
+    , consumerConfigRequestBackoff = Nothing
+    , consumerConfigRequestMaxRequestBatch = Nothing
     , consumerConfigRequestInactiveThreshold = Nothing
     , consumerConfigRequestIdleHeartbeat = Nothing
     , consumerConfigRequestHeadersOnly = Nothing
     , consumerConfigRequestReplicas = Nothing
     , consumerConfigRequestMemoryStorage = Nothing
     }
+
+validateConsumerConfigRequest :: ConsumerConfigRequest -> Either JetStreamError ()
+validateConsumerConfigRequest config = do
+  validateMaxRequestBatch
+  validateBackoffRange
+  validateBackoffLength
+  where
+    validateMaxRequestBatch =
+      case consumerConfigRequestMaxRequestBatch config of
+        Just maxRequestBatch
+          | maxRequestBatch < 0 ->
+              Left (JetStreamDecodeError
+                "consumer max request batch must be zero or greater")
+        _ ->
+          Right ()
+    validateBackoffRange =
+      case consumerConfigRequestBackoff config of
+        Nothing ->
+          Right ()
+        Just backoff ->
+          mapM_ validateBackoffDuration backoff
+    validateBackoffDuration duration =
+      let nanoseconds = diffTimeToNanoseconds duration
+          maxNanoseconds = toInteger (maxBound :: Int64)
+      in if nanoseconds >= 0 && nanoseconds <= maxNanoseconds
+           then Right ()
+           else Left (JetStreamDecodeError
+             "consumer backoff durations must floor to nanoseconds between 0 and 9223372036854775807")
+    validateBackoffLength =
+      case (consumerConfigRequestMaxDeliver config, consumerConfigRequestBackoff config) of
+        (Just maxDeliver, Just backoff)
+          | maxDeliver > 0 && not (null (drop maxDeliver backoff)) ->
+              Left (JetStreamDecodeError
+                "consumer backoff length cannot exceed positive max deliver")
+        _ ->
+          Right ()
 
 applyConsumerTarget :: ConsumerTarget -> ConsumerConfigRequest -> ConsumerConfigRequest
 applyConsumerTarget EphemeralConsumer config =
@@ -233,6 +278,15 @@ withConsumerAckWait :: NominalDiffTime -> ConsumerConfigOption
 withConsumerAckWait ackWait config =
   config { consumerConfigRequestAckWait = Just ackWait }
 
+-- | Configure acknowledgment-timeout redelivery delays (NATS Server 2.7.1+).
+-- This overrides AckWait and does not control explicit NAK redelivery. Values
+-- are floored to whole nanoseconds. The first delay becomes AckWait, the final
+-- delay repeats after the schedule, and the schedule cannot be longer than a
+-- positive MaxDeliver. An empty list leaves the server default.
+withConsumerBackoff :: [NominalDiffTime] -> ConsumerConfigOption
+withConsumerBackoff backoff config =
+  config { consumerConfigRequestBackoff = nonEmpty backoff }
+
 withConsumerMaxDeliver :: Int -> ConsumerConfigOption
 withConsumerMaxDeliver maxDeliver config =
   config { consumerConfigRequestMaxDeliver = Just maxDeliver }
@@ -244,6 +298,12 @@ withConsumerMaxWaiting maxWaiting config =
 withConsumerMaxAckPending :: Int -> ConsumerConfigOption
 withConsumerMaxAckPending maxAckPending config =
   config { consumerConfigRequestMaxAckPending = Just maxAckPending }
+
+-- | Limit a pull consumer request batch (NATS Server 2.7.0+). Zero leaves the
+-- limit unset. This option is only meaningful for pull consumers.
+withConsumerMaxRequestBatch :: Int -> ConsumerConfigOption
+withConsumerMaxRequestBatch maxRequestBatch config =
+  config { consumerConfigRequestMaxRequestBatch = nonZero maxRequestBatch }
 
 withConsumerInactiveThreshold :: NominalDiffTime -> ConsumerConfigOption
 withConsumerInactiveThreshold inactiveThreshold config =
@@ -280,6 +340,8 @@ data ConsumerConfig = ConsumerConfig
                         , consumerConfigMaxDeliver :: Maybe Int
                         , consumerConfigMaxWaiting :: Maybe Int
                         , consumerConfigMaxAckPending :: Maybe Int
+                        , consumerConfigBackoff :: Maybe [NominalDiffTime]
+                        , consumerConfigMaxRequestBatch :: Maybe Int
                         , consumerConfigInactiveThreshold :: Maybe NominalDiffTime
                         , consumerConfigIdleHeartbeat :: Maybe NominalDiffTime
                         , consumerConfigHeadersOnly :: Maybe Bool
@@ -401,6 +463,8 @@ instance ToJSON ConsumerConfigRequest where
       , maybePair "max_deliver" (consumerConfigRequestMaxDeliver config)
       , maybePair "max_waiting" (consumerConfigRequestMaxWaiting config)
       , maybePair "max_ack_pending" (consumerConfigRequestMaxAckPending config)
+      , maybeJsonPair "backoff" (durationListToJSON <$> consumerConfigRequestBackoff config)
+      , maybePair "max_batch" (consumerConfigRequestMaxRequestBatch config)
       , maybeJsonPair "inactive_threshold" (diffTimeNanosToJSON <$> consumerConfigRequestInactiveThreshold config)
       , maybeJsonPair "idle_heartbeat" (diffTimeNanosToJSON <$> consumerConfigRequestIdleHeartbeat config)
       , maybePair "headers_only" (consumerConfigRequestHeadersOnly config)
@@ -425,6 +489,8 @@ instance ToJSON ConsumerConfig where
       , maybePair "max_deliver" (consumerConfigMaxDeliver config)
       , maybePair "max_waiting" (consumerConfigMaxWaiting config)
       , maybePair "max_ack_pending" (consumerConfigMaxAckPending config)
+      , maybeJsonPair "backoff" (durationListToJSON <$> (consumerConfigBackoff config >>= nonEmpty))
+      , maybePair "max_batch" (consumerConfigMaxRequestBatch config >>= nonZero)
       , maybeJsonPair "inactive_threshold" (diffTimeNanosToJSON <$> consumerConfigInactiveThreshold config)
       , maybeJsonPair "idle_heartbeat" (diffTimeNanosToJSON <$> consumerConfigIdleHeartbeat config)
       , maybePair "headers_only" (consumerConfigHeadersOnly config)
@@ -449,6 +515,8 @@ instance FromJSON ConsumerConfig where
       <*> obj .:? "max_deliver"
       <*> obj .:? "max_waiting"
       <*> obj .:? "max_ack_pending"
+      <*> parseOptionalDurationListField obj "backoff"
+      <*> parseOptionalNonZeroIntField obj "max_batch"
       <*> parseOptionalDurationField obj "inactive_threshold"
       <*> parseOptionalDurationField obj "idle_heartbeat"
       <*> obj .:? "headers_only"
@@ -636,6 +704,27 @@ parseOptionalByteStringListField obj key = do
 parseOptionalDurationField :: Object -> Key -> Parser (Maybe NominalDiffTime)
 parseOptionalDurationField obj key =
   fmap nanosToDiffTime <$> obj .:? key
+
+parseOptionalDurationListField :: Object -> Key -> Parser (Maybe [NominalDiffTime])
+parseOptionalDurationListField obj key = do
+  durations <- obj .:? key
+  pure (durations >>= nonEmpty . fmap nanosToDiffTime)
+
+parseOptionalNonZeroIntField :: Object -> Key -> Parser (Maybe Int)
+parseOptionalNonZeroIntField obj key =
+  fmap (>>= nonZero) (obj .:? key)
+
+durationListToJSON :: [NominalDiffTime] -> Value
+durationListToJSON =
+  toJSON . fmap diffTimeToNanoseconds
+
+nonEmpty :: [value] -> Maybe [value]
+nonEmpty []     = Nothing
+nonEmpty values = Just values
+
+nonZero :: (Eq value, Num value) => value -> Maybe value
+nonZero 0     = Nothing
+nonZero value = Just value
 
 nanosToDiffTime :: Integer -> NominalDiffTime
 nanosToDiffTime nanoseconds =

--- a/jetstream/JetStream/Stream.hs
+++ b/jetstream/JetStream/Stream.hs
@@ -14,22 +14,25 @@ import qualified JetStream.Protocol.Subject as Subject
 import           JetStream.Stream.API
 import           JetStream.Stream.Types
     ( StreamAPI (..)
+    , StreamConfigRequest
     , purgeStreamRequest
     , streamConfigRequest
     , streamListRequest
     , streamMessageDeleteRequest
     , streamMessageGetRequest
     , streamNamesRequest
+    , validateStreamConfigRequest
     )
+import           JetStream.Types            (JetStreamRequestOption, Subject)
 
 streamAPI :: JetStreamContext -> StreamAPI
 streamAPI context =
   StreamAPI
     { create = \name subjects options requestOptions ->
         let config = streamConfigRequest name subjects options
-        in Request.requestJSON context
+        in requestStreamConfig context
           (Subject.streamCreateSubject context name)
-          (Just (toJSON config))
+          config
           requestOptions
     , createOrUpdate = \name subjects options requestOptions -> do
         updateResult <- update (streamAPI context) name subjects options requestOptions
@@ -41,9 +44,9 @@ streamAPI context =
             pure other
     , update = \name subjects options requestOptions ->
         let config = streamConfigRequest name subjects options
-        in Request.requestJSON context
+        in requestStreamConfig context
           (Subject.streamUpdateSubject context name)
-          (Just (toJSON config))
+          config
           requestOptions
     , info = \streamName requestOptions ->
         Request.requestJSON context
@@ -77,6 +80,19 @@ streamAPI context =
         Request.requestJSON context (Subject.streamNamesSubject context)
           . Just . toJSON . streamNamesRequest
     }
+
+requestStreamConfig
+  :: JetStreamContext
+  -> Subject
+  -> StreamConfigRequest
+  -> [JetStreamRequestOption]
+  -> IO (Either JetStreamError StreamInfo)
+requestStreamConfig context subject config requestOptions =
+  case validateStreamConfigRequest config of
+    Left err ->
+      pure (Left err)
+    Right () ->
+      Request.requestJSON context subject (Just (toJSON config)) requestOptions
 
 isStreamNotFound :: JetStreamError -> Bool
 isStreamNotFound (JetStreamApiFailure err) =

--- a/jetstream/JetStream/Stream/API.hs
+++ b/jetstream/JetStream/Stream/API.hs
@@ -27,6 +27,7 @@ module JetStream.Stream.API
   , streamConfigMaxMessages
   , streamConfigMaxBytes
   , streamConfigMaxAge
+  , streamConfigMaxMessageSize
   , streamConfigReplicas
   , streamConfigDuplicateWindow
   , streamConfigAllowDirect
@@ -37,6 +38,7 @@ module JetStream.Stream.API
   , withMaxMessages
   , withMaxBytes
   , withMaxAge
+  , withMaxMessageSize
   , withReplicas
   , withDuplicateWindow
   , withAllowDirect

--- a/jetstream/JetStream/Stream/Types.hs
+++ b/jetstream/JetStream/Stream/Types.hs
@@ -8,13 +8,16 @@ module JetStream.Stream.Types
   , DiscardPolicy (..)
   , StreamConfig (..)
   , StreamConfigOption
+  , StreamConfigRequest
   , streamConfigRequest
+  , validateStreamConfigRequest
   , withRetention
   , withStorage
   , withDiscard
   , withMaxMessages
   , withMaxBytes
   , withMaxAge
+  , withMaxMessageSize
   , withReplicas
   , withDuplicateWindow
   , withAllowDirect
@@ -51,10 +54,11 @@ import           Data.Aeson
 import           Data.Aeson.Types       (Pair, Parser)
 import qualified Data.ByteString        as BS
 import qualified Data.ByteString.Base64 as Base64
+import           Data.Int               (Int32)
 import           Data.Maybe             (catMaybes)
 import           Data.Time.Clock        (NominalDiffTime, UTCTime)
 import           Data.Word              (Word64)
-import           JetStream.Error        (JetStreamError)
+import           JetStream.Error        (JetStreamError (JetStreamDecodeError))
 import           JetStream.Types
     ( CallOption
     , DiscardPolicy (..)
@@ -66,6 +70,7 @@ import           JetStream.Types
     , Subject
     , applyCallOptions
     , byteStringToJSON
+    , diffTimeToNanoseconds
     , parseByteString
     )
 
@@ -98,6 +103,7 @@ data StreamConfigRequest = StreamConfigRequest
                              , streamConfigRequestMaxMessages :: Maybe Integer
                              , streamConfigRequestMaxBytes :: Maybe Integer
                              , streamConfigRequestMaxAge :: Maybe NominalDiffTime
+                             , streamConfigRequestMaxMessageSize :: Maybe Int32
                              , streamConfigRequestReplicas :: Maybe Int
                              , streamConfigRequestDuplicateWindow :: Maybe NominalDiffTime
                              , streamConfigRequestAllowDirect :: Maybe Bool
@@ -118,10 +124,20 @@ streamConfigRequest name subjects options =
       , streamConfigRequestMaxMessages = Nothing
       , streamConfigRequestMaxBytes = Nothing
       , streamConfigRequestMaxAge = Nothing
+      , streamConfigRequestMaxMessageSize = Nothing
       , streamConfigRequestReplicas = Nothing
       , streamConfigRequestDuplicateWindow = Nothing
       , streamConfigRequestAllowDirect = Nothing
       }
+
+validateStreamConfigRequest :: StreamConfigRequest -> Either JetStreamError ()
+validateStreamConfigRequest config =
+  case streamConfigRequestMaxMessageSize config of
+    Just maxMessageSize
+      | maxMessageSize < (-1) ->
+          Left (JetStreamDecodeError "stream max message size must be -1 or greater")
+    _ ->
+      Right ()
 
 withRetention :: RetentionPolicy -> StreamConfigOption
 withRetention retention config =
@@ -147,6 +163,12 @@ withMaxAge :: NominalDiffTime -> StreamConfigOption
 withMaxAge maxAge config =
   config { streamConfigRequestMaxAge = Just maxAge }
 
+-- | Limit the total encoded bytes of one stored message, including headers.
+-- Use @-1@ for unlimited.
+withMaxMessageSize :: Int32 -> StreamConfigOption
+withMaxMessageSize maxMessageSize config =
+  config { streamConfigRequestMaxMessageSize = Just maxMessageSize }
+
 withReplicas :: Int -> StreamConfigOption
 withReplicas replicas config =
   config { streamConfigRequestReplicas = Just replicas }
@@ -168,6 +190,7 @@ data StreamConfig = StreamConfig
                       , streamConfigMaxMessages     :: Integer
                       , streamConfigMaxBytes        :: Integer
                       , streamConfigMaxAge          :: NominalDiffTime
+                      , streamConfigMaxMessageSize  :: Int32
                       , streamConfigReplicas        :: Int
                       , streamConfigDuplicateWindow :: Maybe NominalDiffTime
                       , streamConfigAllowDirect     :: Bool
@@ -363,6 +386,7 @@ instance ToJSON StreamConfigRequest where
         , maybePair "max_msgs" (streamConfigRequestMaxMessages config)
         , maybePair "max_bytes" (streamConfigRequestMaxBytes config)
         , maybeDurationPair "max_age" (streamConfigRequestMaxAge config)
+        , maybePair "max_msg_size" (streamConfigRequestMaxMessageSize config)
         , maybePair "num_replicas" (streamConfigRequestReplicas config)
         , maybeDurationPair "duplicate_window" (streamConfigRequestDuplicateWindow config)
         , maybePair "allow_direct" (streamConfigRequestAllowDirect config)
@@ -379,6 +403,7 @@ instance ToJSON StreamConfig where
       , Just ("max_msgs" .= streamConfigMaxMessages config)
       , Just ("max_bytes" .= streamConfigMaxBytes config)
       , Just ("max_age" .= durationToNanoseconds (streamConfigMaxAge config))
+      , Just ("max_msg_size" .= streamConfigMaxMessageSize config)
       , Just ("num_replicas" .= streamConfigReplicas config)
       , maybeDurationPair "duplicate_window" (streamConfigDuplicateWindow config)
       , Just ("allow_direct" .= streamConfigAllowDirect config)
@@ -396,6 +421,7 @@ instance FromJSON StreamConfig where
         <*> value .: "max_msgs"
         <*> value .: "max_bytes"
         <*> parseDurationField value "max_age"
+        <*> value .:? "max_msg_size" .!= (-1)
         <*> value .: "num_replicas"
         <*> parseOptionalDurationField value "duplicate_window"
         <*> value .: "allow_direct"
@@ -638,8 +664,8 @@ parseStoredMessage =
       <*> value .: "time"
 
 durationToNanoseconds :: NominalDiffTime -> Integer
-durationToNanoseconds duration =
-  round (realToFrac duration * (1000000000 :: Double))
+durationToNanoseconds =
+  diffTimeToNanoseconds
 
 nanosecondsToDuration :: Integer -> NominalDiffTime
 nanosecondsToDuration nanoseconds =

--- a/jetstream/JetStream/Types.hs
+++ b/jetstream/JetStream/Types.hs
@@ -23,6 +23,7 @@ module JetStream.Types
   , byteStringToJSON
   , parseByteString
   , diffTimeNanosToJSON
+  , diffTimeToNanoseconds
   , applyCallOptions
   ) where
 
@@ -259,7 +260,12 @@ parseByteString =
 
 diffTimeNanosToJSON :: NominalDiffTime -> Value
 diffTimeNanosToJSON diffTime =
-  Number (fromInteger (floor (realToFrac diffTime * (1000000000 :: Double))))
+  Number (fromInteger (diffTimeToNanoseconds diffTime))
+
+-- | Convert seconds to whole nanoseconds using exact arithmetic and floor.
+diffTimeToNanoseconds :: NominalDiffTime -> Integer
+diffTimeToNanoseconds =
+  floor . (* 1000000000) . toRational
 
 instance FromJSON AccountInfo where
   parseJSON value@(Object obj) =

--- a/natskell.cabal
+++ b/natskell.cabal
@@ -253,6 +253,7 @@ test-suite unit-test
     JetStream.MessageSpec
     JetStream.ProtocolSpec
     JetStream.PublishSpec
+    JetStream.StreamSpec
 
 test-suite fuzz-test
   import:         shared

--- a/system-tests/test/System/JetStreamSpec.hs
+++ b/system-tests/test/System/JetStreamSpec.hs
@@ -102,6 +102,9 @@ spec =
       jetStreamSystemTest "2c1a4ec1-8bc6-4506-8b0c-a128ca670c09"
         "orders filtered headers-only messages"
         orderedFilteredHeadersOnlyTest
+      jetStreamSystemTest "9bba145b-28a5-41fb-8512-47eaa66269c9"
+        "enforces stream and pull consumer resource limits"
+        resourceLimitsTest
       jetStreamSystemTest "ff173d87-7377-4ff5-a6c8-83574508b591"
         "stops push consumer subscriptions gracefully"
         pushConsumerGracefulShutdownTest
@@ -902,6 +905,47 @@ orderedConsumerGracefulShutdownTest jetStream = do
     ]
     []
   fetchAfterStop `shouldBe` Left JetStream.JetStreamNoReply
+
+resourceLimitsTest :: JetStream -> IO ()
+resourceLimitsTest jetStream = do
+  let stream = "NATSKELL_JS_RESOURCE_LIMITS"
+      subject = "NATSKELL.JS.RESOURCE_LIMITS"
+      durable = "RESOURCE_LIMITS"
+      backoff = [0.05, 0.1]
+  streamInfo <- createStreamOrFail jetStream stream [subject]
+    (streamOptions ++ [JetStream.withMaxMessageSize 4])
+  JetStream.streamConfigMaxMessageSize (JetStream.streamInfoConfig streamInfo)
+    `shouldBe` 4
+  publishPayload jetStream subject "1234"
+  oversize <- JetStream.publish (publisher jetStream) subject "12345" [] []
+  expectJetStreamFailure "publish above max message size" oversize
+  encodedHeaderOversize <- JetStream.publish (publisher jetStream) subject "1"
+    [ JetStream.withMsgId "resource-limits-message"
+    , JetStream.withHeaders [("Resource-Limit", "header")]
+    ]
+    []
+  expectJetStreamFailure "publish whose encoded headers exceed max message size" encodedHeaderOversize
+
+  consumerInfo <- createDurableConsumerOrFail jetStream stream durable $
+    pullConsumerOptions durable
+      [ JetStream.withConsumerMaxDeliver 2
+      , JetStream.withConsumerBackoff backoff
+      , JetStream.withConsumerMaxRequestBatch 2
+      ]
+  let config = JetStream.consumerInfoConfig consumerInfo
+  JetStream.consumerConfigBackoff config `shouldBe` Just backoff
+  JetStream.consumerConfigMaxRequestBatch config `shouldBe` Just 2
+  oversizedBatch <- expectRight "fetch above consumer max request batch" $
+    JetStream.fetch (messages jetStream) stream durable
+      [ JetStream.withFetchBatch 3
+      , JetStream.withFetchWait (JetStream.FetchNoWaitMicros 100000)
+      ]
+      []
+  case JetStream.pullResponseStatus oversizedBatch of
+    Just (JetStream.PullStatusError "409" (Just description)) ->
+      description `shouldSatisfy` BS.isInfixOf "MaxRequestBatch"
+    other ->
+      expectationFailure ("expected max request batch status, got " ++ show other)
 
 domainJetStreamTest :: JetStream -> IO ()
 domainJetStreamTest jetStream = do

--- a/test/Integration/ClientSpec.hs
+++ b/test/Integration/ClientSpec.hs
@@ -47,6 +47,10 @@ isValidationFailure :: Either NatsError a -> Bool
 isValidationFailure (Left (NatsValidationError _)) = True
 isValidationFailure _                              = False
 
+isJetStreamDecodeFailure :: Either JetStream.JetStreamError a -> Bool
+isJetStreamDecodeFailure (Left (JetStream.JetStreamDecodeError _)) = True
+isJetStreamDecodeFailure _                                         = False
+
 tooLongMSG = "MSG a b 5000\r\n" <> BS.replicate 5000 _x <> "\r\n"
 
 headerBlock :: [(BS.ByteString, BS.ByteString)] -> BS.ByteString
@@ -328,11 +332,11 @@ replyStatusToCapturedPublish sock captured status description =
 
 protoStreamInfoResponse :: BS.ByteString
 protoStreamInfoResponse =
-  "{\"config\":{\"name\":\"PROTO_STREAM\",\"subjects\":[\"PROTO.SUBJECT\"],\"retention\":\"limits\",\"storage\":\"memory\",\"discard\":\"new\",\"max_msgs\":1,\"max_bytes\":-1,\"max_age\":0,\"num_replicas\":1,\"allow_direct\":false},\"created\":\"2024-01-01T00:00:00Z\",\"state\":{\"messages\":0,\"bytes\":0,\"first_seq\":0,\"first_ts\":\"2024-01-01T00:00:00Z\",\"last_seq\":0,\"last_ts\":\"2024-01-01T00:00:00Z\",\"consumer_count\":0}}"
+  "{\"config\":{\"name\":\"PROTO_STREAM\",\"subjects\":[\"PROTO.SUBJECT\"],\"retention\":\"limits\",\"storage\":\"memory\",\"discard\":\"new\",\"max_msgs\":1,\"max_bytes\":-1,\"max_age\":0,\"max_msg_size\":64,\"num_replicas\":1,\"allow_direct\":false},\"created\":\"2024-01-01T00:00:00Z\",\"state\":{\"messages\":0,\"bytes\":0,\"first_seq\":0,\"first_ts\":\"2024-01-01T00:00:00Z\",\"last_seq\":0,\"last_ts\":\"2024-01-01T00:00:00Z\",\"consumer_count\":0}}"
 
 protoConsumerInfoResponse :: BS.ByteString
 protoConsumerInfoResponse =
-  "{\"stream_name\":\"PROTO_STREAM\",\"name\":\"PROTO_CONSUMER\",\"created\":\"2024-01-01T00:00:00Z\",\"config\":{\"deliver_policy\":\"all\",\"ack_policy\":\"explicit\",\"replay_policy\":\"instant\",\"filter_subjects\":[\"PROTO.A\",\"PROTO.B\"]}}"
+  "{\"stream_name\":\"PROTO_STREAM\",\"name\":\"PROTO_CONSUMER\",\"created\":\"2024-01-01T00:00:00Z\",\"config\":{\"deliver_policy\":\"all\",\"ack_policy\":\"explicit\",\"replay_policy\":\"instant\",\"filter_subjects\":[\"PROTO.A\",\"PROTO.B\"],\"backoff\":[100000001,250000000],\"max_batch\":32}}"
 
 protoPushConsumerInfoResponse :: BS.ByteString
 protoPushConsumerInfoResponse =
@@ -801,12 +805,14 @@ spec = do
               ["PROTO.SUBJECT"]
               [ JetStream.withStorage JetStream.MemoryStorage
               , JetStream.withMaxMessages 1
+              , JetStream.withMaxMessageSize 64
               , JetStream.withDiscard JetStream.DiscardNew
               ]
               []
             putMVar done result
           captured <- capturePublish serv "$JS.API.STREAM.CREATE.PROTO_STREAM"
           capturedPayload captured `shouldSatisfy` BS.isInfixOf "\"max_msgs\":1"
+          capturedPayload captured `shouldSatisfy` BS.isInfixOf "\"max_msg_size\":64"
           capturedPayload captured `shouldSatisfy` BS.isInfixOf "\"discard\":\"new\""
           replyToCapturedPublish serv captured protoStreamInfoResponse
           result <- timeout 1000000 (takeMVar done)
@@ -815,8 +821,9 @@ spec = do
               expectationFailure "stream create did not complete"
             Just (Left err) ->
               expectationFailure ("stream create failed: " ++ show err)
-            Just (Right info) ->
+            Just (Right info) -> do
               JetStream.streamConfigName (JetStream.streamInfoConfig info) `shouldBe` "PROTO_STREAM"
+              JetStream.streamConfigMaxMessageSize (JetStream.streamInfoConfig info) `shouldBe` 64
 
         it "sends only the selected consumer filter representation" $ \(serv, client, _, _) -> do
           let Right jetStream = newJetStream client []
@@ -832,12 +839,16 @@ spec = do
               , JetStream.withConsumerAckPolicy JetStream.AckExplicit
               , JetStream.withConsumerFilter
                   (JetStream.ConsumerFilterSubjects ["PROTO.A", "PROTO.B"])
+              , JetStream.withConsumerBackoff [0.100000001, 0.25]
+              , JetStream.withConsumerMaxRequestBatch 32
               ]
               []
             putMVar done result
           captured <- capturePublish serv "$JS.API.CONSUMER.DURABLE.CREATE.PROTO_STREAM.PROTO_CONSUMER"
           capturedPayload captured `shouldSatisfy` BS.isInfixOf "\"filter_subjects\":[\"PROTO.A\",\"PROTO.B\"]"
           capturedPayload captured `shouldSatisfy` not . BS.isInfixOf "\"filter_subject\":"
+          capturedPayload captured `shouldSatisfy` BS.isInfixOf "\"backoff\":[100000001,250000000]"
+          capturedPayload captured `shouldSatisfy` BS.isInfixOf "\"max_batch\":32"
           replyToCapturedPublish serv captured protoConsumerInfoResponse
           result <- timeout 1000000 (takeMVar done)
           case result of
@@ -845,8 +856,64 @@ spec = do
               expectationFailure "consumer create did not complete"
             Just (Left err) ->
               expectationFailure ("consumer create failed: " ++ show err)
-            Just (Right info) ->
+            Just (Right info) -> do
               JetStream.consumerInfoName info `shouldBe` "PROTO_CONSUMER"
+              JetStream.consumerConfigBackoff (JetStream.consumerInfoConfig info)
+                `shouldBe` Just [0.100000001, 0.25]
+              JetStream.consumerConfigMaxRequestBatch (JetStream.consumerInfoConfig info)
+                `shouldBe` Just 32
+
+        it "rejects invalid resource configs before publishing" $ \(serv, client, _, _) -> do
+          let Right jetStream = newJetStream client []
+          invalidStream <- JetStream.create
+            (JetStream.streams jetStream)
+            "INVALID_STREAM"
+            ["INVALID.STREAM"]
+            [JetStream.withMaxMessageSize (-2)]
+            []
+          invalidStream `shouldSatisfy` isJetStreamDecodeFailure
+
+          invalidBatch <- JetStream.putConsumer
+            (JetStream.consumers jetStream)
+            "PROTO_STREAM"
+            JetStream.ConsumerCreate
+            (JetStream.DurableConsumer "INVALID_BATCH")
+            JetStream.PullConsumer
+            [JetStream.withConsumerMaxRequestBatch (-1)]
+            []
+          invalidBatch `shouldSatisfy` isJetStreamDecodeFailure
+
+          invalidBackoff <- JetStream.putConsumer
+            (JetStream.consumers jetStream)
+            "PROTO_STREAM"
+            JetStream.ConsumerCreate
+            (JetStream.DurableConsumer "INVALID_BACKOFF")
+            JetStream.PullConsumer
+            [JetStream.withConsumerBackoff [10000000000]]
+            []
+          invalidBackoff `shouldSatisfy` isJetStreamDecodeFailure
+
+          invalidBackoffLength <- JetStream.putConsumer
+            (JetStream.consumers jetStream)
+            "PROTO_STREAM"
+            JetStream.ConsumerCreate
+            (JetStream.DurableConsumer "INVALID_BACKOFF_LENGTH")
+            JetStream.PullConsumer
+            [ JetStream.withConsumerMaxDeliver 1
+            , JetStream.withConsumerBackoff [1, 2]
+            ]
+            []
+          invalidBackoffLength `shouldSatisfy` isJetStreamDecodeFailure
+
+          pingBox <- newEmptyMVar
+          pingWithCallback client (putMVar pingBox ())
+          expectNoClientBytesBefore
+            serv
+            (BS.isInfixOf "$JS.API.")
+            "PING\r\n"
+            "invalid JetStream config published a request"
+          sendAll serv "PONG\r\n"
+          expectMVar "PING failed after local JetStream validation" pingBox
 
         it "sends push consumer create requests with a delivery subject" $ \(serv, client, _, _) -> do
           let Right jetStream = newJetStream client []

--- a/test/PublicAPI/Main.hs
+++ b/test/PublicAPI/Main.hs
@@ -94,13 +94,16 @@ jetStreamOperations jetStream = do
     ["orders.>"]
     [ Stream.withStorage Stream.FileStorage
     , Stream.withMaxMessages 1000
+    , Stream.withMaxMessageSize 1024
     ]
     []
   case created of
     Left _       -> pure ()
     Right handle -> do
-      _ <- Stream.getStreamInfo (JetStream.streams jetStream) handle []
-      pure ()
+      info <- Stream.getStreamInfo (JetStream.streams jetStream) handle []
+      case info of
+        Left _       -> pure ()
+        Right detail -> Stream.streamConfigMaxMessageSize (Stream.streamInfoConfig detail) `seq` pure ()
   _ <- JetStreamPublish.publish
     (JetStream.publisher jetStream)
     "orders.created"
@@ -113,13 +116,20 @@ jetStreamOperations jetStream = do
     Consumer.ConsumerCreate
     (Consumer.DurableConsumer "processor")
     Consumer.PullConsumer
-    [Consumer.withConsumerAckPolicy Consumer.AckExplicit]
+    [ Consumer.withConsumerAckPolicy Consumer.AckExplicit
+    , Consumer.withConsumerBackoff [1, 2]
+    , Consumer.withConsumerMaxRequestBatch 64
+    ]
     []
   case consumer of
     Left _       -> pure ()
     Right handle -> do
-      _ <- Consumer.getConsumerInfo (JetStream.consumers jetStream) handle []
-      pure ()
+      info <- Consumer.getConsumerInfo (JetStream.consumers jetStream) handle []
+      case info of
+        Left _       -> pure ()
+        Right detail -> do
+          Consumer.consumerConfigBackoff (Consumer.consumerInfoConfig detail) `seq` pure ()
+          Consumer.consumerConfigMaxRequestBatch (Consumer.consumerInfoConfig detail) `seq` pure ()
   _ <- JetStreamMessage.fetch
     (JetStream.messages jetStream)
     "ORDERS"

--- a/test/Unit/JetStream/ConsumerSpec.hs
+++ b/test/Unit/JetStream/ConsumerSpec.hs
@@ -10,7 +10,12 @@ import           Data.Aeson
     , (.=)
     )
 import qualified Data.ByteString.Lazy     as LBS
+import           Data.Int                 (Int64)
+import           Data.Ratio               ((%))
 import           JetStream.Consumer.Types
+import           JetStream.Error
+    ( JetStreamError (JetStreamDecodeError)
+    )
 import           Test.Hspec
 
 spec :: Spec
@@ -34,6 +39,57 @@ spec = do
       eitherDecode (encode request)
         `shouldBe` Right (object ["deliver_policy" .= ("last" :: String)])
 
+    it "encodes backoff durations as exact integer nanoseconds" $ do
+      let request = consumerConfigRequest
+            [ withConsumerBackoff
+                [ fromRational (1234567891 % 1000000000)
+                , fromRational (1 % 1000000000)
+                ]
+            , withConsumerMaxRequestBatch maxBound
+            ]
+      validateConsumerConfigRequest request `shouldBe` Right ()
+      eitherDecode (encode request) `shouldBe` Right (object
+        [ "backoff" .= [1234567891 :: Integer, 1]
+        , "max_batch" .= (maxBound :: Int)
+        ])
+
+    it "floors backoff at sub-nanosecond and Int64 boundaries" $ do
+      let request = consumerConfigRequest
+            [withConsumerBackoff [subNanosecond, oneNanosecond, maxInt64Nanoseconds]]
+      validateConsumerConfigRequest request `shouldBe` Right ()
+      eitherDecode (encode request) `shouldBe` Right (object
+        ["backoff" .= [0 :: Integer, 1, toInteger (maxBound :: Int64)]])
+
+    it "rejects negative and overflowing backoff durations" $ do
+      validateConsumerConfigRequest
+        (consumerConfigRequest [withConsumerBackoff [negativeSubNanosecond]])
+        `shouldBe` Left (JetStreamDecodeError backoffRangeError)
+      validateConsumerConfigRequest
+        (consumerConfigRequest [withConsumerBackoff [overflowingNanoseconds]])
+        `shouldBe` Left (JetStreamDecodeError backoffRangeError)
+
+    it "rejects negative max request batch" $ do
+      validateConsumerConfigRequest
+        (consumerConfigRequest [withConsumerMaxRequestBatch (-1)])
+        `shouldBe` Left (JetStreamDecodeError "consumer max request batch must be zero or greater")
+
+    it "allows backoff no longer than positive max deliver" $ do
+      validateConsumerConfigRequest (backoffWithMaxDeliver 2 [1]) `shouldBe` Right ()
+      validateConsumerConfigRequest (backoffWithMaxDeliver 2 [1, 2]) `shouldBe` Right ()
+      validateConsumerConfigRequest (backoffWithMaxDeliver 0 [1, 2, 3]) `shouldBe` Right ()
+      validateConsumerConfigRequest (backoffWithMaxDeliver (-1) [1, 2, 3]) `shouldBe` Right ()
+      validateConsumerConfigRequest (backoffWithMaxDeliver 2 [1, 2, 3])
+        `shouldBe` Left (JetStreamDecodeError
+          "consumer backoff length cannot exceed positive max deliver")
+
+    it "omits empty backoff and zero max request batch values" $ do
+      let request = consumerConfigRequest
+            [ withConsumerBackoff []
+            , withConsumerMaxRequestBatch 0
+            ]
+      validateConsumerConfigRequest request `shouldBe` Right ()
+      eitherDecode (encode request) `shouldBe` Right (object [])
+
   describe "Consumer reset request JSON" $ do
     it "encodes an optional reset sequence" $ do
       eitherDecode (encode (consumerResetRequest [withConsumerResetSequence 7]))
@@ -42,6 +98,15 @@ spec = do
   describe "ConsumerInfo JSON" .
     it "decodes server responses into concrete fields" $ do
       eitherDecode consumerInfoJSON `shouldBe` Right consumerInfoFixture
+
+  describe "ConsumerConfig response JSON" $ do
+    it "normalizes absent backoff and zero max request batch to unset" $ do
+      fmap configResourceLimits (eitherDecode zeroMaxBatchConsumerConfigJSON)
+        `shouldBe` Right (Nothing, Nothing)
+
+    it "round-trips backoff and max request batch" $ do
+      eitherDecode (encode (consumerInfoConfig consumerInfoFixture))
+        `shouldBe` Right (consumerInfoConfig consumerInfoFixture)
 
   describe "ConsumerResetResponse JSON" .
     it "decodes reset metadata with the updated consumer info" $ do
@@ -66,6 +131,30 @@ spec = do
           , consumerNamesLimit = 1024
           , consumerNamesConsumers = ["orders-puller", "orders-worker"]
           }
+
+configResourceLimits config =
+  (consumerConfigBackoff config, consumerConfigMaxRequestBatch config)
+
+backoffWithMaxDeliver maxDeliver backoff =
+  consumerConfigRequest
+    [ withConsumerMaxDeliver maxDeliver
+    , withConsumerBackoff backoff
+    ]
+
+subNanosecond = fromRational (1 % 2000000000)
+
+negativeSubNanosecond = fromRational ((-1) % 2000000000)
+
+oneNanosecond = fromRational (1 % 1000000000)
+
+maxInt64Nanoseconds =
+  fromRational (toInteger (maxBound :: Int64) % 1000000000)
+
+overflowingNanoseconds =
+  fromRational ((toInteger (maxBound :: Int64) + 1) % 1000000000)
+
+backoffRangeError =
+  "consumer backoff durations must floor to nanoseconds between 0 and 9223372036854775807"
 
 durablePullConsumerConfigRequest :: ConsumerConfigRequest
 durablePullConsumerConfigRequest =
@@ -142,7 +231,11 @@ targetKindConsumerConfigValue = object
 
 consumerInfoJSON :: LBS.ByteString
 consumerInfoJSON =
-  "{\"type\":\"io.nats.jetstream.api.v1.consumer_info_response\",\"stream_name\":\"ORDERS\",\"name\":\"orders-puller\",\"created\":\"2024-01-01T00:00:00Z\",\"config\":{\"deliver_policy\":\"all\",\"ack_policy\":\"explicit\",\"replay_policy\":\"instant\"},\"delivered\":{\"consumer_seq\":2,\"stream_seq\":10},\"ack_floor\":{\"consumer_seq\":1,\"stream_seq\":9},\"num_ack_pending\":1,\"num_redelivered\":0,\"num_waiting\":0,\"num_pending\":3}"
+  "{\"type\":\"io.nats.jetstream.api.v1.consumer_info_response\",\"stream_name\":\"ORDERS\",\"name\":\"orders-puller\",\"created\":\"2024-01-01T00:00:00Z\",\"config\":{\"deliver_policy\":\"all\",\"ack_policy\":\"explicit\",\"replay_policy\":\"instant\",\"backoff\":[1000000001,2],\"max_batch\":128},\"delivered\":{\"consumer_seq\":2,\"stream_seq\":10},\"ack_floor\":{\"consumer_seq\":1,\"stream_seq\":9},\"num_ack_pending\":1,\"num_redelivered\":0,\"num_waiting\":0,\"num_pending\":3}"
+
+zeroMaxBatchConsumerConfigJSON :: LBS.ByteString
+zeroMaxBatchConsumerConfigJSON =
+  "{\"deliver_policy\":\"all\",\"ack_policy\":\"explicit\",\"replay_policy\":\"instant\",\"max_batch\":0}"
 
 consumerResetJSON :: LBS.ByteString
 consumerResetJSON =
@@ -150,7 +243,7 @@ consumerResetJSON =
 
 consumerListJSON :: LBS.ByteString
 consumerListJSON =
-  "{\"type\":\"io.nats.jetstream.api.v1.consumer_list_response\",\"total\":1,\"offset\":0,\"limit\":1024,\"consumers\":[{\"type\":\"io.nats.jetstream.api.v1.consumer_info_response\",\"stream_name\":\"ORDERS\",\"name\":\"orders-puller\",\"created\":\"2024-01-01T00:00:00Z\",\"config\":{\"deliver_policy\":\"all\",\"ack_policy\":\"explicit\",\"replay_policy\":\"instant\"},\"delivered\":{\"consumer_seq\":2,\"stream_seq\":10},\"ack_floor\":{\"consumer_seq\":1,\"stream_seq\":9},\"num_ack_pending\":1,\"num_redelivered\":0,\"num_waiting\":0,\"num_pending\":3}]}"
+  "{\"type\":\"io.nats.jetstream.api.v1.consumer_list_response\",\"total\":1,\"offset\":0,\"limit\":1024,\"consumers\":[{\"type\":\"io.nats.jetstream.api.v1.consumer_info_response\",\"stream_name\":\"ORDERS\",\"name\":\"orders-puller\",\"created\":\"2024-01-01T00:00:00Z\",\"config\":{\"deliver_policy\":\"all\",\"ack_policy\":\"explicit\",\"replay_policy\":\"instant\",\"backoff\":[1000000001,2],\"max_batch\":128},\"delivered\":{\"consumer_seq\":2,\"stream_seq\":10},\"ack_floor\":{\"consumer_seq\":1,\"stream_seq\":9},\"num_ack_pending\":1,\"num_redelivered\":0,\"num_waiting\":0,\"num_pending\":3}]}"
 
 consumerNamesJSON :: LBS.ByteString
 consumerNamesJSON =
@@ -176,6 +269,8 @@ consumerInfoFixture = ConsumerInfo
       , consumerConfigMaxDeliver = Nothing
       , consumerConfigMaxWaiting = Nothing
       , consumerConfigMaxAckPending = Nothing
+      , consumerConfigBackoff = Just [fromRational (1000000001 % 1000000000), fromRational (2 % 1000000000)]
+      , consumerConfigMaxRequestBatch = Just 128
       , consumerConfigInactiveThreshold = Nothing
       , consumerConfigIdleHeartbeat = Nothing
       , consumerConfigHeadersOnly = Nothing

--- a/test/Unit/JetStream/StreamSpec.hs
+++ b/test/Unit/JetStream/StreamSpec.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module JetStream.StreamSpec (spec) where
+
+import           Data.Aeson             (eitherDecode, encode, object, (.=))
+import qualified Data.ByteString.Lazy   as LBS
+import           Data.Int               (Int32)
+import           JetStream.Error        (JetStreamError (JetStreamDecodeError))
+import           JetStream.Stream.Types
+import           Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "StreamConfig request JSON" $ do
+    it "omits max message size unless configured" $ do
+      let request = streamConfigRequest "ORDERS" ["orders.>"] []
+      eitherDecode (encode request) `shouldBe` Right (object
+        [ "name" .= ("ORDERS" :: String)
+        , "subjects" .= ["orders.>" :: String]
+        ])
+
+    it "encodes valid max message size boundaries" $ do
+      let encodedMaxMessageSize value =
+            eitherDecode . encode $
+              streamConfigRequest "ORDERS" [] [withMaxMessageSize value]
+          validatedMaxMessageSize value =
+            validateStreamConfigRequest $
+              streamConfigRequest "ORDERS" [] [withMaxMessageSize value]
+          expected value = object
+            [ "name" .= ("ORDERS" :: String)
+            , "subjects" .= ([] :: [String])
+            , "max_msg_size" .= value
+            ]
+      encodedMaxMessageSize (-1) `shouldBe` Right (expected (-1 :: Int32))
+      encodedMaxMessageSize 0 `shouldBe` Right (expected (0 :: Int32))
+      encodedMaxMessageSize maxBound `shouldBe` Right (expected (maxBound :: Int32))
+      validatedMaxMessageSize (-1) `shouldBe` Right ()
+      validatedMaxMessageSize 0 `shouldBe` Right ()
+      validatedMaxMessageSize maxBound `shouldBe` Right ()
+
+    it "rejects max message sizes below unlimited" $ do
+      validateStreamConfigRequest
+        (streamConfigRequest "ORDERS" [] [withMaxMessageSize (-2)])
+        `shouldBe` Left (JetStreamDecodeError "stream max message size must be -1 or greater")
+      validateStreamConfigRequest
+        (streamConfigRequest "ORDERS" [] [withMaxMessageSize minBound])
+        `shouldBe` Left (JetStreamDecodeError "stream max message size must be -1 or greater")
+
+  describe "StreamConfig response JSON" $ do
+    it "normalizes a missing max message size to unlimited" $ do
+      fmap streamConfigMaxMessageSize (eitherDecode streamConfigWithoutMaxMessageSizeJSON)
+        `shouldBe` Right (-1)
+
+    it "round-trips max message size" $ do
+      eitherDecode (encode streamConfigFixture) `shouldBe` Right streamConfigFixture
+
+streamConfigFixture :: StreamConfig
+streamConfigFixture =
+  StreamConfig
+    { streamConfigName = "ORDERS"
+    , streamConfigSubjects = Just ["orders.>"]
+    , streamConfigRetention = LimitsPolicy
+    , streamConfigStorage = MemoryStorage
+    , streamConfigDiscard = DiscardOld
+    , streamConfigMaxMessages = -1
+    , streamConfigMaxBytes = -1
+    , streamConfigMaxAge = 0
+    , streamConfigMaxMessageSize = maxBound
+    , streamConfigReplicas = 1
+    , streamConfigDuplicateWindow = Nothing
+    , streamConfigAllowDirect = False
+    }
+
+streamConfigWithoutMaxMessageSizeJSON :: LBS.ByteString
+streamConfigWithoutMaxMessageSizeJSON =
+  "{\"name\":\"ORDERS\",\"subjects\":[\"orders.>\"],\"retention\":\"limits\",\"storage\":\"memory\",\"discard\":\"old\",\"max_msgs\":-1,\"max_bytes\":-1,\"max_age\":0,\"num_replicas\":1,\"allow_direct\":false}"


### PR DESCRIPTION
## Summary

- add validated stream `max_msg_size` support
- add consumer backoff schedules with exact nanosecond encoding
- add pull-consumer `max_batch` support
- normalize omitted server defaults through public accessors

## Safety

Invalid negative limits, duration overflow, and backoff schedules longer than a positive `max_deliver` fail locally before any NATS request is sent.

## Verification

- `nix flake check`
- unit suite: 161,137 examples
- public API compile test
- fake integration tests, including no-request validation paths
- real NATS tests for header-inclusive stream limits, backoff round-trip, and max-batch enforcement
- Stylish Haskell and HLint

## Compatibility

Additive public options and accessors only; public configuration records remain opaque.
