### PR TITLE
Release natskell 1.1.0.0

### DIFF
--- a/natskell.cabal
+++ b/natskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   natskell
-version:                1.0.0.1
+version:                1.1.0.0
 synopsis:               A NATS client library written in Haskell
 tested-with:
   GHC ==8.8,


### PR DESCRIPTION
## Summary

Bump the package version to 1.1.0.0 after merging:

- cancellation-safe core client lifecycle, typed state/error events, and reconnect generation invariants
- confirmed JetStream ACK/TERM and delayed NAK dispositions
- JetStream stream max-message-size and consumer backoff/max-batch limits

## Verification

- nix flake check path:.
- cabal check
- source distribution builds as natskell-1.1.0.0.tar.gz
- feature PRs passed unit, fuzz, public API, integration, system, package, and GHC 8.8-9.14 matrix checks