### PR TITLE
chore: release 1.1.0.1

### DIFF
--- a/natskell.cabal
+++ b/natskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   natskell
-version:                1.1.0.0
+version:                1.1.0.1
 synopsis:               A NATS client library written in Haskell
 tested-with:
   GHC ==8.8,


### PR DESCRIPTION
Publishes the strict request/reply subscription-state fix from #189 as natskell 1.1.0.1. Supersedes #190 with a signed commit required by main protection.