### PR TITLE
Add reusable JetStream pull subscriptions

### DIFF
--- a/jetstream/JetStream/Message.hs
+++ b/jetstream/JetStream/Message.hs
@@ -10,6 +10,7 @@ module JetStream.Message
   ) where
 
 import qualified Client.API                 as Nats
+import           Control.Concurrent.MVar    (modifyMVar, newMVar)
 import           Control.Concurrent.STM
 import           Control.Exception          (bracket)
 import           Control.Monad              (unless, void)
@@ -69,6 +70,7 @@ messageAPI context consumerAPI =
   MessageAPI
     { fetch = \stream consumer options requestOptions ->
         fetchMessages context stream consumer (pullRequest options) requestOptions
+    , consumePull = consumePullMessages context
     , consumePush = \deliverSubject options _ handler ->
         consumePushMessages context deliverSubject (pushConsumeConfig options) handler
     , createOrderedConsumer = \stream options requestOptions ->
@@ -82,6 +84,62 @@ messageAPI context consumerAPI =
     , term = sendDisposition context ConfirmWhenRequested (ackPayload Term)
     , termSync = sendDisposition context ConfirmAlways (ackPayload Term)
     }
+
+consumePullMessages
+  :: JetStreamContext
+  -> StreamName
+  -> ConsumerName
+  -> (PullEvent -> IO ())
+  -> IO (Either JetStreamError PullSubscription)
+consumePullMessages context stream consumer handler = do
+  inbox <- Nats.newInbox natsClient
+  subscription <- Nats.subscribe natsClient inbox [] $ \msgView ->
+    let message = fromMsgView msgView
+    in case messageStatus message of
+         Nothing     -> handler (PullMessage message)
+         Just status -> handler (PullStatusMessage status)
+  case subscription of
+    Left err ->
+      pure (Left (JetStreamNatsError err))
+    Right handle -> do
+      stopped <- newMVar False
+      pure $ Right PullSubscription
+        { requestPull = \options ->
+            let request = pullRequest options
+            in modifyMVar stopped $ \isStopped ->
+                 if isStopped
+                   then pure (True, Left JetStreamNoReply)
+                   else do
+                     result <- requestPullMessages context stream consumer inbox request
+                     pure (False, result)
+        , stopPullSubscription =
+            modifyMVar stopped $ \isStopped ->
+              if isStopped
+                then pure (True, Right ())
+                else do
+                  result <- mapNatsResult <$> Nats.unsubscribe natsClient handle []
+                  pure (True, result)
+        }
+  where
+    natsClient = contextClient context
+
+requestPullMessages
+  :: JetStreamContext
+  -> StreamName
+  -> ConsumerName
+  -> Subject
+  -> PullRequest
+  -> IO (Either JetStreamError ())
+requestPullMessages context stream consumer inbox request
+  | pullRequestBatch request <= 0 =
+      pure (Right ())
+  | otherwise =
+      mapNatsResult <$>
+        Nats.publish
+          (contextClient context)
+          (Subject.consumerNextSubject context stream consumer)
+          (pullRequestPayload (pullRequestBatch request) request)
+          [Nats.withReplyTo inbox]
 
 consumePushMessages
   :: JetStreamContext

--- a/jetstream/JetStream/Message/API.hs
+++ b/jetstream/JetStream/Message/API.hs
@@ -1,6 +1,7 @@
 module JetStream.Message.API
   ( MessageAPI
   , fetch
+  , consumePull
   , consumePush
   , createOrderedConsumer
   , ack
@@ -39,6 +40,10 @@ module JetStream.Message.API
   , PushConsumeOption
   , PushSubscription
   , stopPushSubscription
+  , PullEvent (..)
+  , PullSubscription
+  , requestPull
+  , stopPullSubscription
   , PullResponse
   , pullResponseMessages
   , pullResponseStatus
@@ -64,12 +69,15 @@ import           JetStream.Message.Types
     , NakDelay
     , OrderedConsumer
     , OrderedConsumerOption
+    , PullEvent (..)
     , PullResponse
     , PullStatus (..)
+    , PullSubscription
     , PushConsumeOption
     , PushSubscription
     , ack
     , ackSync
+    , consumePull
     , consumePush
     , createOrderedConsumer
     , fetch
@@ -95,7 +103,9 @@ import           JetStream.Message.Types
     , orderedConsumerInfo
     , pullResponseMessages
     , pullResponseStatus
+    , requestPull
     , stopOrderedConsumer
+    , stopPullSubscription
     , stopPushSubscription
     , term
     , termSync

--- a/jetstream/JetStream/Message/Types.hs
+++ b/jetstream/JetStream/Message/Types.hs
@@ -15,8 +15,10 @@ module JetStream.Message.Types
   , PushConsumeConfig (..)
   , PushConsumeOption
   , PushSubscription (..)
+  , PullEvent (..)
   , PullRequest (..)
   , PullResponse (..)
+  , PullSubscription (..)
   , PullStatus (..)
   , ackPayload
   , classifyStatusHeaders
@@ -73,6 +75,7 @@ import           JetStream.Types
 -- hides the constructor so this capability can grow additively.
 data MessageAPI = MessageAPI
                     { fetch :: StreamName -> ConsumerName -> [FetchOption] -> [JetStreamRequestOption] -> IO (Either JetStreamError PullResponse)
+                    , consumePull :: StreamName -> ConsumerName -> (PullEvent -> IO ()) -> IO (Either JetStreamError PullSubscription)
                     , consumePush :: Subject -> [PushConsumeOption] -> [JetStreamRequestOption] -> (Message -> IO ()) -> IO (Either JetStreamError PushSubscription)
                     , createOrderedConsumer :: StreamName -> [OrderedConsumerOption] -> [JetStreamRequestOption] -> IO (Either JetStreamError OrderedConsumer)
                     , ack :: Message -> [JetStreamRequestOption] -> IO (Either JetStreamError ())
@@ -121,6 +124,12 @@ data PullResponse = PullResponse
                       }
   deriving (Eq, Show)
 
+-- | One reply received by a persistent pull subscription. Status replies end
+-- or reject a server-side pull request without being application messages.
+data PullEvent = PullMessage Message
+               | PullStatusMessage PullStatus
+  deriving (Eq, Show)
+
 data Message = Message
                  { messageSubject :: Subject
                  , messagePayload :: Payload
@@ -143,6 +152,13 @@ data MessageMetadata = MessageMetadata
   deriving (Eq, Show)
 
 newtype PushSubscription = PushSubscription { stopPushSubscription :: IO (Either JetStreamError ()) }
+
+-- | One reusable reply inbox for explicit pull requests. Requests may select
+-- different batch sizes while the subscription remains active.
+data PullSubscription = PullSubscription
+                          { requestPull :: [FetchOption] -> IO (Either JetStreamError ())
+                          , stopPullSubscription :: IO (Either JetStreamError ())
+                          }
 
 newtype PushConsumeConfig = PushConsumeConfig { pushConsumeQueueGroup :: Maybe Subject }
 

--- a/system-tests/test/System/JetStreamSpec.hs
+++ b/system-tests/test/System/JetStreamSpec.hs
@@ -2,22 +2,27 @@
 
 module JetStreamSpec (spec) where
 
-import qualified API                   as Nats
-import           Client                (withConnectName)
+import qualified API                     as Nats
+import           Client                  (withConnectName)
 import           Control.Concurrent
     ( newEmptyMVar
     , takeMVar
     , threadDelay
     , tryPutMVar
     )
-import           Control.Exception     (finally)
-import           Control.Monad         (forM_, unless, void, when)
-import qualified Data.ByteString       as BS
-import qualified Data.ByteString.Char8 as BC
-import           Data.IORef            (atomicModifyIORef', newIORef, readIORef)
-import           Data.List             (sort)
-import           Data.Maybe            (fromMaybe)
-import           Data.Time.Clock       (addUTCTime, getCurrentTime)
+import           Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
+import           Control.Exception       (finally)
+import           Control.Monad           (forM_, unless, void, when)
+import qualified Data.ByteString         as BS
+import qualified Data.ByteString.Char8   as BC
+import           Data.IORef
+    ( atomicModifyIORef'
+    , newIORef
+    , readIORef
+    )
+import           Data.List               (sort)
+import           Data.Maybe              (fromMaybe)
+import           Data.Time.Clock         (addUTCTime, getCurrentTime)
 import           JetStream.API
     ( JetStream
     , consumers
@@ -25,10 +30,10 @@ import           JetStream.API
     , publisher
     , streams
     )
-import qualified JetStream.API         as JetStream
-import           JetStream.Client      (newJetStream, withDomain)
+import qualified JetStream.API           as JetStream
+import           JetStream.Client        (newJetStream, withDomain)
 import           NatsServerConfig
-import           System.Timeout        (timeout)
+import           System.Timeout          (timeout)
 import           Test.Hspec
 import           TestSupport
 
@@ -39,6 +44,9 @@ spec =
       jetStreamSystemTest "33d3fe4e-d2b8-4e91-8f9e-58a817c5575f"
         "acks a durable pull message and reports no messages"
         durablePullConsumerTest
+      jetStreamSystemTest "4135c93b-a889-4ce4-9c72-59475778f29d"
+        "reuses a persistent pull subscription across batch requests"
+        persistentPullSubscriptionTest
       jetStreamSystemTest "a617d120-8846-48b0-a76d-b6a5975ee1c8"
         "deduplicates publishes by message id"
         duplicatePublishTest
@@ -184,6 +192,104 @@ durablePullConsumerTest jetStream = do
     JetStream.fetch (messages jetStream) streamName durableName shortFetch []
   JetStream.pullResponseMessages emptyFetch `shouldBe` []
   expectNoMessages emptyFetch
+
+persistentPullSubscriptionTest :: JetStream -> IO ()
+persistentPullSubscriptionTest jetStream = do
+  let stream = "NATSKELL_JS_PERSISTENT_PULL"
+      subject = "NATSKELL.JS.PERSISTENT.PULL"
+      consumer = "PERSISTENT_PULL_WORKER"
+  createStreamOrFail jetStream stream [subject] streamOptions
+  createDurableConsumerOrFail
+    jetStream
+    stream
+    consumer
+    (pullConsumerOptions consumer [])
+  events <- newChan
+  subscription <- expectRight "persistent pull subscribe" $
+    JetStream.consumePull
+      (messages jetStream)
+      stream
+      consumer
+      (writeChan events)
+
+  flip finally (void (JetStream.stopPullSubscription subscription)) $ do
+    mapM_ (publishPayload jetStream subject) ["one", "two", "three"]
+    JetStream.requestPull
+      subscription
+      [ JetStream.withFetchBatch 2
+      , JetStream.withFetchWait (JetStream.FetchExpiresMicros 1000000)
+      ]
+      `shouldReturn` Right ()
+    first <- nextPullMessage events
+    second <- nextPullMessage events
+    fmap JetStream.messagePayload [first, second]
+      `shouldBe` ["one", "two"]
+    mapM_ (ackOrFail jetStream) [first, second]
+
+    JetStream.requestPull
+      subscription
+      [ JetStream.withFetchBatch 1
+      , JetStream.withFetchWait (JetStream.FetchExpiresMicros 1000000)
+      ]
+      `shouldReturn` Right ()
+    third <- nextPullMessage events
+    JetStream.messagePayload third `shouldBe` "three"
+    ackOrFail jetStream third
+
+    publishPayload jetStream subject "partial"
+    JetStream.requestPull
+      subscription
+      [ JetStream.withFetchBatch 2
+      , JetStream.withFetchWait (JetStream.FetchExpiresMicros 100000)
+      ]
+      `shouldReturn` Right ()
+    partial <- nextPullMessage events
+    JetStream.messagePayload partial `shouldBe` "partial"
+    ackOrFail jetStream partial
+    nextPullStatus events
+      `shouldReturn` JetStream.PullRequestTimeout (Just "Request Timeout")
+
+    JetStream.requestPull
+      subscription
+      [ JetStream.withFetchBatch 1
+      , JetStream.withFetchWait (JetStream.FetchExpiresMicros 1000000)
+      ]
+      `shouldReturn` Right ()
+    publishPayload jetStream subject "after-timeout"
+    afterTimeout <- nextPullMessage events
+    JetStream.messagePayload afterTimeout `shouldBe` "after-timeout"
+    ackOrFail jetStream afterTimeout
+
+nextPullMessage
+  :: Chan JetStream.PullEvent
+  -> IO JetStream.Message
+nextPullMessage events = do
+  received <- timeout 5000000 (readChan events)
+  case received of
+    Just (JetStream.PullMessage message) ->
+      pure message
+    Just (JetStream.PullStatusMessage status) ->
+      expectationFailure ("unexpected persistent pull status: " ++ show status) >>
+        fail "unexpected persistent pull status"
+    Nothing ->
+      expectationFailure "persistent pull delivery timed out" >>
+        fail "persistent pull delivery timed out"
+
+nextPullStatus :: Chan JetStream.PullEvent -> IO JetStream.PullStatus
+nextPullStatus events = do
+  received <- timeout 5000000 (readChan events)
+  case received of
+    Just (JetStream.PullStatusMessage status) ->
+      pure status
+    Just (JetStream.PullMessage message) ->
+      expectationFailure
+        ( "unexpected persistent pull message while awaiting status: "
+            ++ show (JetStream.messagePayload message)
+        ) >>
+        fail "unexpected persistent pull message"
+    Nothing ->
+      expectationFailure "persistent pull status timed out" >>
+        fail "persistent pull status timed out"
 
 duplicatePublishTest :: JetStream -> IO ()
 duplicatePublishTest jetStream = do

--- a/test/PublicAPI/Main.hs
+++ b/test/PublicAPI/Main.hs
@@ -168,6 +168,19 @@ jetStreamOperations jetStream = do
     "processor"
     [JetStreamMessage.withFetchBatch 10]
     []
+  pullSubscription <- JetStreamMessage.consumePull
+    (JetStream.messages jetStream)
+    "ORDERS"
+    "processor"
+    observePullEvent
+  case pullSubscription of
+    Left _ -> pure ()
+    Right handle -> do
+      _ <- JetStreamMessage.requestPull
+        handle
+        [JetStreamMessage.withFetchBatch 10]
+      _ <- JetStreamMessage.stopPullSubscription handle
+      pure ()
   _ <- JetStreamMessage.consumePush
     (JetStream.messages jetStream)
     "deliver.orders"
@@ -211,6 +224,14 @@ jetStreamOperations jetStream = do
             (JetStream.keyValues jetStream) handle []
           pure ()
   pure ()
+
+observePullEvent :: JetStreamMessage.PullEvent -> IO ()
+observePullEvent event =
+  case event of
+    JetStreamMessage.PullMessage message ->
+      JetStreamMessage.messagePayload message `seq` pure ()
+    JetStreamMessage.PullStatusMessage status ->
+      status `seq` pure ()
 
 messageOperations
   :: JetStream.MessageAPI

--- a/test/Unit/JetStream/MessageSpec.hs
+++ b/test/Unit/JetStream/MessageSpec.hs
@@ -228,6 +228,63 @@ spec = do
       unsubscribeCalls' <- readIORef unsubscribeCalls
       unsubscribeCalls' `shouldBe` ["sid-timeout"]
 
+  describe "persistent pull" $ do
+    it "reuses one reply subscription across batched pull requests" $ do
+      publishCalls <- newIORef []
+      subscribeCalls <- newIORef []
+      unsubscribeCalls <- newIORef []
+      callbackRef <- newIORef Nothing
+      events <- newIORef []
+      let client = persistentPullFakeClient
+            publishCalls
+            subscribeCalls
+            unsubscribeCalls
+            callbackRef
+          api = messageAPI
+            (newJetStreamContext client [])
+            (error "unused consumer API")
+
+      subscriptionResult <- consumePull api "ORDERS" "WORKER" $ \event ->
+        modifyIORef' events (++ [event])
+      subscription <-
+        case subscriptionResult of
+          Left err ->
+            expectationFailure ("pull subscription failed: " ++ show err) >>
+              fail "pull subscription failed"
+          Right value ->
+            pure value
+
+      requestPull subscription [withFetchBatch 2] `shouldReturn` Right ()
+      requestPull
+        subscription
+        [ withFetchBatch 3
+        , withFetchWait (FetchNoWaitMicros 1000)
+        ]
+        `shouldReturn` Right ()
+
+      readIORef subscribeCalls `shouldReturn` ["_INBOX.persistent"]
+      readIORef publishCalls `shouldReturn`
+        [ ( "$JS.API.CONSUMER.MSG.NEXT.ORDERS.WORKER"
+          , "{\"batch\":2,\"expires\":1000000000}"
+          , Just "_INBOX.persistent"
+          )
+        , ( "$JS.API.CONSUMER.MSG.NEXT.ORDERS.WORKER"
+          , "{\"batch\":3,\"no_wait\":true}"
+          , Just "_INBOX.persistent"
+          )
+        ]
+      readIORef events `shouldReturn`
+        [ PullMessage (fromFakeMsg (fakeMsg "one"))
+        , PullMessage (fromFakeMsg (fakeMsg "two"))
+        , PullStatusMessage (PullNoMessages (Just "No Messages"))
+        ]
+
+      stopPullSubscription subscription `shouldReturn` Right ()
+      stopPullSubscription subscription `shouldReturn` Right ()
+      readIORef unsubscribeCalls `shouldReturn` ["sid-persistent"]
+      requestPull subscription [withFetchBatch 1]
+        `shouldReturn` Left JetStreamNoReply
+
 fakeClient
   :: IORef [(Subject, Payload, Maybe Subject)]
   -> IORef [SID]
@@ -270,6 +327,65 @@ fakeMsg body =
     , Nats.replyTo = Just "$JS.ACK.ORDERS.WORKER.1.1.1"
     , Nats.payload = body
     , Nats.headers = Nothing
+    }
+
+fromFakeMsg :: Nats.Message -> Message
+fromFakeMsg value =
+  Message
+    { messageSubject = Nats.subject value
+    , messagePayload = Nats.payload value
+    , messageHeaders = Nats.headers value
+    , messageReplyTo = Nats.replyTo value
+    , messageStatus = classifyStatusHeaders (Nats.headers value)
+    }
+
+persistentPullFakeClient
+  :: IORef [(Subject, Payload, Maybe Subject)]
+  -> IORef [Subject]
+  -> IORef [SID]
+  -> IORef (Maybe (Nats.MsgView -> IO ()))
+  -> Nats.Client
+persistentPullFakeClient publishCalls subscribeCalls unsubscribeCalls callbackRef =
+  Nats.Client
+    { Nats.publish = \subject body options -> do
+        let replyTo' = publishReplyTo (foldl (flip ($)) defaultPublishConfig options)
+        modifyIORef' publishCalls (++ [(subject, body, replyTo')])
+        callback <- readIORef callbackRef
+        case callback of
+          Nothing ->
+            pure ()
+          Just deliver
+            | body == "{\"batch\":2,\"expires\":1000000000}" -> do
+                deliver (fakeMsg "one")
+                deliver (fakeMsg "two")
+            | otherwise ->
+                deliver
+                  Nats.Message
+                    { Nats.subject = "_INBOX.persistent"
+                    , Nats.sid = "sid-persistent"
+                    , Nats.replyTo = Nothing
+                    , Nats.payload = ""
+                    , Nats.headers = Just
+                        [ ("Status", "404")
+                        , ("Description", "No Messages")
+                        ]
+                    }
+        pure (Right ())
+    , Nats.subscribe = \subject _ callback -> do
+        modifyIORef' subscribeCalls (++ [subject])
+        writeIORef callbackRef (Just callback)
+        pure (Right (Nats.Subscription "sid-persistent"))
+    , Nats.subscribeOnce = \_ _ _ -> pure (Right (Nats.Subscription "sid-once"))
+    , Nats.request = \_ _ _ -> pure (Left Nats.NatsRequestTimedOut)
+    , Nats.unsubscribe = \(Nats.Subscription sid) _ -> do
+        modifyIORef' unsubscribeCalls (++ [sid])
+        pure (Right ())
+    , Nats.newInbox = pure "_INBOX.persistent"
+    , Nats.ping = \_ -> pure (Right ())
+    , Nats.flush = \_ -> pure (Right ())
+    , Nats.connectionState = pure Nats.ConnectionConnected
+    , Nats.reset = \_ -> pure ()
+    , Nats.close = \_ -> pure ()
     }
 
 silentFakeClient


### PR DESCRIPTION
## Summary
- add a persistent pull subscription API with explicit batch requests
- expose messages and pull status events immediately
- cover inbox reuse, partial batches, expiry, shutdown, and public API compilation

## Verification
- nix flake check
- full unit, fuzz, integration, and system test suites