### PR TITLE
fix(tls): fill backend receives

### DIFF
--- a/internal/Plumbing/Network/Connection/Tls.hs
+++ b/internal/Plumbing/Network/Connection/Tls.hs
@@ -1,10 +1,12 @@
 module Network.Connection.Tls
   ( configureTransport
+  , receiveExactly
   , upgradeTcp
   ) where
 
 import           Control.Exception
 import           Control.Monad
+import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Char8      as BC
 import qualified Data.ByteString.Lazy       as LBS
 import           Data.Maybe                 (fromMaybe)
@@ -46,7 +48,7 @@ upgradeTcp :: NS.Socket -> TLS.ClientParams -> IO (Either String Transport)
 upgradeTcp sock params = mask $ \restore -> do
   let backend = TLS.Backend
         { TLS.backendSend = NSB.sendAll sock
-        , TLS.backendRecv = NSB.recv sock
+        , TLS.backendRecv = receiveExactly (NSB.recv sock)
         , TLS.backendFlush = pure ()
         , TLS.backendClose = NS.close sock
         }
@@ -58,6 +60,19 @@ upgradeTcp sock params = mask $ \restore -> do
   case result of
     Left err        -> return $ Left (show err)
     Right transport -> return $ Right transport
+
+receiveExactly :: (Int -> IO BS.ByteString) -> Int -> IO BS.ByteString
+receiveExactly receive =
+  go []
+  where
+    go chunks remaining
+      | remaining <= 0 =
+          pure (BS.concat (reverse chunks))
+      | otherwise = do
+          chunk <- receive remaining
+          if BS.null chunk
+            then pure (BS.concat (reverse chunks))
+            else go (chunk : chunks) (remaining - BS.length chunk)
 
 upgradeToTLS :: Conn -> TLS.ClientParams -> IO (Either String ())
 upgradeToTLS conn params = mask_ $ do

--- a/natskell.cabal
+++ b/natskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   natskell
-version:                1.3.0.1
+version:                1.3.0.0
 synopsis:               A NATS client library written in Haskell
 tested-with:
   GHC ==8.8,

--- a/natskell.cabal
+++ b/natskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   natskell
-version:                1.3.0.0
+version:                1.3.0.1
 synopsis:               A NATS client library written in Haskell
 tested-with:
   GHC ==8.8,

--- a/system-tests/test/System/ClientAuthTlsCertSpec.hs
+++ b/system-tests/test/System/ClientAuthTlsCertSpec.hs
@@ -6,7 +6,11 @@ import           API
 import           Client
 import           Control.Concurrent     (forkIO)
 import           Control.Concurrent.STM
+import           Control.Exception      (finally)
+import           Control.Monad          (void)
+import qualified Data.ByteString        as BS
 import           NatsServerConfig
+import           System.Timeout         (timeout)
 import           Test.Hspec
 import           TestSupport
 
@@ -56,6 +60,25 @@ spec =
           atomically (putTMVar pinged ())
           result <- atomically $ readTMVar exitResult
           result `shouldBe` ExitClosedByUser
+        it "receives large messages intact across partial tls reads" $ \(Endpoints natsHost natsPort) -> do
+          received <- newEmptyTMVarIO
+          let body = BS.replicate (128 * 1024) 120
+              clientOptions =
+                [ withConnectName "auth-tls-large-message"
+                , withTLSCert (clientCert, clientKey)
+                , withTLSRootCA tlsRoot
+                , withConnectionAttempts 1
+                ]
+                ++ loggerOptions
+          client <- newTestClient [(natsHost, natsPort)] clientOptions
+          (do
+              void (subscribe client "TLS.LARGE" [] (atomically . putTMVar received . payload))
+              flush client []
+              void (publish client "TLS.LARGE" body [])
+              flush client []
+              result <- timeout (5 * 1000000) (atomically (takeTMVar received))
+              result `shouldBe` Just body)
+            `finally` close client []
         it "rejects tls client without required certificate" $ \(Endpoints natsHost natsPort) -> do
           exitResult <- newEmptyTMVarIO
           let clientOptions =

--- a/test/Unit/ConnectionSpec.hs
+++ b/test/Unit/ConnectionSpec.hs
@@ -24,6 +24,7 @@ import           Lib.Logger
     )
 import           Network.Connection        (connectionApi)
 import           Network.Connection.Core   (Transport (..), pointTransport)
+import           Network.Connection.Tls    (receiveExactly)
 import           Network.ConnectionAPI
     ( ConnectionAPI (..)
     , ReaderAPI (..)
@@ -174,6 +175,27 @@ spec = do
       show config `shouldNotContain` "private-key"
       show config `shouldNotContain` "private-root"
       show config `shouldContain` "tlsRootCertificates = 1 configured"
+
+    it "fills each TLS backend receive across partial socket reads" $ do
+      chunks <- newMVar ["ab", "c", "de"]
+      requested <- newMVar []
+      let receive count = do
+            modifyMVar_ requested (pure . (<> [count]))
+            modifyMVar chunks $ \case
+              []           -> pure ([], BS.empty)
+              next : rest -> pure (rest, next)
+
+      receiveExactly receive 5 `shouldReturn` "abcde"
+      readMVar requested `shouldReturn` [5, 3, 2]
+
+    it "returns a partial receive only when the socket reaches EOF" $ do
+      chunks <- newMVar ["ab"]
+      let receive _ =
+            modifyMVar chunks $ \case
+              []           -> pure ([], BS.empty)
+              next : rest -> pure (rest, next)
+
+      receiveExactly receive 5 `shouldReturn` "ab"
 
   describe "Connection reader" $ do
     it "unblocks a blocking read when closeReader is called" $ do


### PR DESCRIPTION
## Summary
- fill `Network.TLS` backend receives across partial socket reads
- preserve partial results only when socket reaches EOF

## Verification
- full unit suite: 161195 examples
- real NATS mTLS regression: 128 KiB message arrives intact
- `hlint .`
- `nix flake check`
