### PR TITLE
chore: release 1.3.0.1

### DIFF
--- a/natskell.cabal
+++ b/natskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   natskell
-version:                1.3.0.0
+version:                1.3.0.1
 synopsis:               A NATS client library written in Haskell
 tested-with:
   GHC ==8.8,


### PR DESCRIPTION
## Summary
- release natskell 1.3.0.1
- include exact TLS backend receives for fragmented large messages

## Verification
- `nix flake check`
- pull request #196 unit, integration, system, and GHC matrix checks
