### PR TITLE
feat(tls): add renewable config source

### DIFF
--- a/AGENT_LESSONS.md
+++ b/AGENT_LESSONS.md
@@ -6,6 +6,7 @@ Workarounds in this environment:
 - System tests require Docker/network access; rerun with escalated permissions if sandboxed.
 - `stylish-haskell -ri -c stylish.yaml .` sometimes exits 1 with no output here; rerun with `-v` (`stylish-haskell -rvi -c stylish.yaml .`) to get diagnostics.
 - `stylish-haskell` may not be on the ambient PATH under `rtk`; run it through the dev shell, e.g. `rtk nix develop -c stylish-haskell -rvi -c stylish.yaml .`.
+- Pass only Haskell source paths to `stylish-haskell`; including Markdown makes it parse the document as Haskell and fail.
 - `nix flake check` can exceed the default command timeout; rerun with a longer timeout in this harness.
 - GHC 8.8 / older `bytestring` does not expose `Data.ByteString.dropWhileEnd`; use a local compatibility helper built from `BS.reverse . BS.dropWhile predicate . BS.reverse`.
 - nix commands only sees tracked files; new modules must live under tracked paths or be added by the user.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ enables TLS without additional material.
 `withTLSInsecure` disables verification and should only be used in controlled
 test environments.
 
+`withTLSConfigSource` reads a complete mutual-TLS `TLSConfig` immediately
+before every TLS connection and reconnection. Source configurations require a
+client certificate, at least one root, a server name, and verification enabled.
+They replace static TLS options; the last TLS option wins. A source failure is
+reported as `ConnectTLSConfigSourceFailure` without including certificate or
+key material in diagnostics.
+
 ### JetStream
 
 JetStream is part of the main `natskell` library. No separate package is

--- a/client/Client.hs
+++ b/client/Client.hs
@@ -24,6 +24,7 @@ module Client
   , withTLSRootCA
   , withTLSServerName
   , withTLSInsecure
+  , withTLSConfigSource
   , withMinimumLogLevel
   , withLogAction
   , withConnectionAttempts
@@ -53,6 +54,8 @@ module Client
   , TLSPrivateKey
   , TLSCertData
   , TLSConfig (..)
+  , TLSConfigSource
+  , TLSConfigSourceFailure (..)
   , ClientExitReason (..)
   , ConnectionEvent (..)
   , ServerError

--- a/client/Client/Implementation.hs
+++ b/client/Client/Implementation.hs
@@ -27,6 +27,7 @@ module Client.Implementation
   , withTLSRootCA
   , withTLSServerName
   , withTLSInsecure
+  , withTLSConfigSource
   , withMinimumLogLevel
   , withLogAction
   , withConnectionAttempts
@@ -56,6 +57,8 @@ module Client.Implementation
   , TLSPrivateKey
   , TLSCertData
   , TLSConfig (..)
+  , TLSConfigSource
+  , TLSConfigSourceFailure (..)
   , ClientExitReason (..)
   , ConnectionEvent (..)
   , ServerError
@@ -194,6 +197,8 @@ import           State.Types
     , ServerErrorKind (..)
     , TLSCertData
     , TLSConfig (..)
+    , TLSConfigSource
+    , TLSConfigSourceFailure (..)
     , TLSPrivateKey
     , TLSPublicKey
     , defaultTLSConfig
@@ -235,6 +240,7 @@ data ClientOptions = ClientOptions
                        { optionConnectConfig :: Connect.Connect
                        , optionAuth :: Auth
                        , optionTlsConfig :: Maybe TLSConfig
+                       , optionTlsConfigSource :: Maybe TLSConfigSource
                        , optionLoggerConfig :: LoggerConfig
                        , optionConnectionAttempts :: Int
                        , optionConnectTimeoutMicros :: Int
@@ -294,6 +300,7 @@ newClient servers configOptions = mask $ \restoreInitialWait -> do
         { optionConnectConfig = defaultConnect
         , optionAuth = AuthNone.auth
         , optionTlsConfig = Nothing
+        , optionTlsConfigSource = Nothing
         , optionLoggerConfig = loggerConfig'
         , optionConnectionAttempts = 5
         , optionConnectTimeoutMicros = 2 * 1000000
@@ -315,6 +322,7 @@ newClient servers configOptions = mask $ \restoreInitialWait -> do
           , connectConfig = optionConnectConfig defaultOptions
           , loggerConfig = optionLoggerConfig defaultOptions
           , tlsConfig = optionTlsConfig defaultOptions
+          , tlsConfigSource = optionTlsConfigSource defaultOptions
           , serverErrorHandler = optionServerErrorHandler defaultOptions
           , connectionEventHandler = optionConnectionEventHandler defaultOptions
           , exitAction = optionExitAction defaultOptions
@@ -533,11 +541,23 @@ withTLSInsecure :: ConfigOption
 withTLSInsecure =
   modifyTLSConfig $ \tls -> tls { tlsInsecure = True }
 
+-- | Fetch complete mutual-TLS configuration before every TLS handshake.
+--
+-- This is intended for renewable identities such as SPIFFE SVIDs. It replaces
+-- static TLS options; applying a static TLS option afterwards replaces source.
+withTLSConfigSource :: TLSConfigSource -> ConfigOption
+withTLSConfigSource source config =
+  config
+    { optionTlsConfig = Nothing
+    , optionTlsConfigSource = Just source
+    }
+
 modifyTLSConfig :: (TLSConfig -> TLSConfig) -> ConfigOption
 modifyTLSConfig update config =
   config
     { optionTlsConfig =
         Just (update (fromMaybe defaultTLSConfig (optionTlsConfig config)))
+    , optionTlsConfigSource = Nothing
     }
 
 withMinimumLogLevel :: LogLevel -> ConfigOption
@@ -659,10 +679,10 @@ logStaticConfiguration client options =
       [] -> logMessage Info "no authentication method provided"
       methods -> forM_ methods $ \method ->
         logMessage Info ("using " ++ method)
-    case optionTlsConfig options of
-      Nothing ->
-        pure ()
-      Just tls -> do
+    case (optionTlsConfig options, optionTlsConfigSource options) of
+      (Nothing, Nothing) -> pure ()
+      (Nothing, Just _) -> logMessage Info "using renewable tls configuration"
+      (Just tls, _) -> do
         logMessage Info "using tls"
         when (tlsInsecure tls) $
           logMessage Warn "tls certificate verification is disabled"

--- a/internal/Policy/Engine.hs
+++ b/internal/Policy/Engine.hs
@@ -321,11 +321,13 @@ runEngine connectionApi streamingApi broadcastingApi parserApi state store auth 
 
     handshakeFailure (HandshakeTransportError err) = ConnectTransportFailure err
     handshakeFailure (HandshakeTLSError err) = ConnectTLSFailure err
+    handshakeFailure (HandshakeTLSConfigSourceError err) = ConnectTLSConfigSourceFailure err
     handshakeFailure (HandshakeProtocolError err) = ConnectProtocolFailure err
     handshakeFailure (HandshakeAuthError err) = ConnectAuthenticationFailure (show err)
 
     failureCategory (ConnectTransportFailure _)      = "transport failure"
     failureCategory (ConnectTLSFailure _)            = "tls failure"
+    failureCategory (ConnectTLSConfigSourceFailure _) = "tls configuration source failure"
     failureCategory (ConnectProtocolFailure _)       = "protocol failure"
     failureCategory (ConnectAuthenticationFailure _) = "authentication failure"
     failureCategory ConnectHandshakeTimeout          = "handshake timeout"

--- a/internal/Policy/Handshake/Nats.hs
+++ b/internal/Policy/Handshake/Nats.hs
@@ -42,10 +42,15 @@ import qualified Types.Err                 as Err
 import qualified Types.Info                as I
 import           Types.Ping                (Ping (Ping))
 import           Types.Pong                (Pong (Pong))
-import           Types.TLS                 (defaultTLSConfig)
+import           Types.TLS
+    ( TLSConfigSourceFailure
+    , defaultTLSConfig
+    , readTLSConfigSource
+    )
 
 data HandshakeError = HandshakeTransportError String
                     | HandshakeTLSError String
+                    | HandshakeTLSConfigSourceError TLSConfigSourceFailure
                     | HandshakeProtocolError String
                     | HandshakeAuthError AuthError
   deriving (Eq, Show)
@@ -63,53 +68,63 @@ performHandshake connectionApi parserApi state auth conn host = handshake
           pure (Left err)
         Right (info, rest) -> do
           let cfg = config state
-              tlsRequested = isJust (tlsConfig cfg) || Connect.tls_required (connectConfig cfg)
+              tlsRequested =
+                isJust (tlsConfig cfg)
+                  || isJust (tlsConfigSource cfg)
+                  || Connect.tls_required (connectConfig cfg)
               tlsRequired = fromMaybe False (I.tls_required info)
               tlsAvailable = fromMaybe False (I.tls_available info)
               useTls = tlsRequired || (tlsRequested && tlsAvailable)
-              transportOption =
-                TransportOption
-                  { transportHost = host
-                  , transportTlsRequired = tlsRequired
-                  , transportTlsRequested = tlsRequested && tlsAvailable
-                  , transportTlsConfig =
-                      if useTls
-                        then Just (fromMaybe defaultTLSConfig (tlsConfig cfg))
-                        else Nothing
-                  , transportInitialBytes = rest
-                  }
           if tlsRequested && not (tlsRequired || tlsAvailable)
             then pure (Left (HandshakeTLSError "server does not offer TLS"))
             else do
-              transportResult <- configure connectionApi conn transportOption
-              case transportResult of
-                Left err ->
-                  pure (Left (HandshakeTLSError err))
-                Right () -> do
-                  setServerInfo state info
-                  updateLogContextFromInfo state info
-                  let authContext = AuthContext { authNonce = I.nonce info }
-                      connectPayload =
-                        (connectConfig cfg)
-                          { Connect.tls_required = useTls
+              tlsResult <- resolveTlsConfig cfg useTls
+              case tlsResult of
+                Left err -> pure (Left (HandshakeTLSConfigSourceError err))
+                Right tls -> do
+                  let transportOption =
+                        TransportOption
+                          { transportHost = host
+                          , transportTlsRequired = tlsRequired
+                          , transportTlsRequested = tlsRequested && tlsAvailable
+                          , transportTlsConfig = tls
+                          , transportInitialBytes = rest
                           }
-                  authResult <- buildAuthPatch auth authContext
-                  case authResult of
+                  transportResult <- configure connectionApi conn transportOption
+                  case transportResult of
                     Left err ->
-                      pure (Left (HandshakeAuthError err))
-                    Right patch -> do
-                      writeResult <-
-                        writeDataLazy
-                          (writer connectionApi)
-                          conn
-                          ( transform (applyAuthPatch patch connectPayload)
-                              <> transform Ping
-                          )
-                      case writeResult of
+                      pure (Left (HandshakeTLSError err))
+                    Right () -> do
+                      setServerInfo state info
+                      updateLogContextFromInfo state info
+                      let authContext = AuthContext { authNonce = I.nonce info }
+                          connectPayload =
+                            (connectConfig cfg)
+                              { Connect.tls_required = useTls
+                              }
+                      authResult <- buildAuthPatch auth authContext
+                      case authResult of
                         Left err ->
-                          pure (Left (HandshakeTransportError err))
-                        Right () ->
-                          awaitPong mempty
+                          pure (Left (HandshakeAuthError err))
+                        Right patch -> do
+                          writeResult <-
+                            writeDataLazy
+                              (writer connectionApi)
+                              conn
+                              ( transform (applyAuthPatch patch connectPayload)
+                                  <> transform Ping
+                              )
+                          case writeResult of
+                            Left err ->
+                              pure (Left (HandshakeTransportError err))
+                            Right () ->
+                              awaitPong mempty
+
+    resolveTlsConfig _ False = pure (Right Nothing)
+    resolveTlsConfig cfg True =
+      case tlsConfigSource cfg of
+        Just source -> fmap Just <$> readTLSConfigSource source
+        Nothing -> pure (Right (Just (fromMaybe defaultTLSConfig (tlsConfig cfg))))
 
     readInitialInfo :: IO (Either HandshakeError (I.Info, BS.ByteString))
     readInitialInfo = readMore mempty

--- a/internal/Policy/State/Types.hs
+++ b/internal/Policy/State/Types.hs
@@ -5,6 +5,8 @@ module State.Types
   , TLSPrivateKey
   , TLSCertData
   , TLSConfig (..)
+  , TLSConfigSource
+  , TLSConfigSourceFailure (..)
   , defaultTLSConfig
   , ClientConfig (..)
   , ConnectError (..)
@@ -35,6 +37,7 @@ data ClientConfig = ClientConfig
                       , connectConfig          :: Connect
                       , loggerConfig           :: LoggerConfig
                       , tlsConfig              :: Maybe TLSConfig
+                      , tlsConfigSource        :: Maybe TLSConfigSource
                       , serverErrorHandler     :: ServerError -> IO ()
                       , connectionEventHandler :: ConnectionEvent -> IO ()
                       , exitAction             :: ClientExitReason -> IO ()
@@ -56,6 +59,7 @@ data ConnectAttemptError = ConnectAttemptError
 -- | The stage at which a connection attempt failed.
 data ConnectFailure = ConnectTransportFailure String
                     | ConnectTLSFailure String
+                    | ConnectTLSConfigSourceFailure TLSConfigSourceFailure
                     | ConnectProtocolFailure String
                     | ConnectAuthenticationFailure String
                     | ConnectHandshakeTimeout

--- a/internal/Types/TLS.hs
+++ b/internal/Types/TLS.hs
@@ -3,11 +3,21 @@ module Types.TLS
   , TLSPrivateKey
   , TLSCertData
   , TLSConfig (..)
+  , TLSConfigSource
+  , TLSConfigSourceFailure (..)
   , defaultTLSConfig
+  , readTLSConfigSource
   ) where
 
-import qualified Data.ByteString as BS
-import           Data.Maybe      (isJust)
+import           Control.Exception
+    ( SomeAsyncException
+    , SomeException
+    , fromException
+    , throwIO
+    , try
+    )
+import qualified Data.ByteString   as BS
+import           Data.Maybe        (isJust)
 
 type TLSPublicKey = BS.ByteString
 type TLSPrivateKey = BS.ByteString
@@ -21,6 +31,19 @@ data TLSConfig = TLSConfig
                    , tlsInsecure          :: Bool
                    }
   deriving (Eq)
+
+-- | Reads a complete mutual-TLS configuration snapshot for one connection.
+--
+-- Sources are invoked immediately before each TLS handshake, including
+-- reconnects and client resets.
+type TLSConfigSource = IO (Either TLSConfigSourceFailure TLSConfig)
+
+-- | Stable failure categories for renewable TLS configuration.
+--
+-- Raw source exceptions are intentionally not exposed because they can contain
+-- certificate paths, secret-manager responses, or other private details.
+data TLSConfigSourceFailure = TLSConfigSourceUnavailable | TLSConfigSourceIncomplete
+  deriving (Eq, Show)
 
 instance Show TLSConfig where
   show config =
@@ -45,3 +68,27 @@ defaultTLSConfig =
     , tlsServerName = Nothing
     , tlsInsecure = False
     }
+
+-- | Read and validate a source snapshot without leaking source exceptions.
+--
+-- Mutual-TLS sources must include their complete trust and identity material.
+-- This prevents a certificate/key rotation from accidentally combining files
+-- from different SVID generations with static client options.
+readTLSConfigSource :: TLSConfigSource -> IO (Either TLSConfigSourceFailure TLSConfig)
+readTLSConfigSource source = do
+  result <- try source :: IO (Either SomeException (Either TLSConfigSourceFailure TLSConfig))
+  case result of
+    Left err ->
+      case fromException err :: Maybe SomeAsyncException of
+        Just _  -> throwIO err
+        Nothing -> pure (Left TLSConfigSourceUnavailable)
+    Right (Left err) -> pure (Left err)
+    Right (Right config)
+      | complete config -> pure (Right config)
+      | otherwise       -> pure (Left TLSConfigSourceIncomplete)
+  where
+    complete config =
+      isJust (tlsClientCertificate config)
+        && not (null (tlsRootCertificates config))
+        && isJust (tlsServerName config)
+        && not (tlsInsecure config)

--- a/natskell.cabal
+++ b/natskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   natskell
-version:                1.4.0.0
+version:                1.3.0.1
 synopsis:               A NATS client library written in Haskell
 tested-with:
   GHC ==8.8,

--- a/natskell.cabal
+++ b/natskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   natskell
-version:                1.3.0.1
+version:                1.4.0.0
 synopsis:               A NATS client library written in Haskell
 tested-with:
   GHC ==8.8,

--- a/system-tests/test/System/ClientAuthTlsCertSpec.hs
+++ b/system-tests/test/System/ClientAuthTlsCertSpec.hs
@@ -9,6 +9,11 @@ import           Control.Concurrent.STM
 import           Control.Exception      (finally)
 import           Control.Monad          (void)
 import qualified Data.ByteString        as BS
+import           Data.IORef
+    ( atomicModifyIORef'
+    , newIORef
+    , readIORef
+    )
 import           NatsServerConfig
 import           System.Timeout         (timeout)
 import           Test.Hspec
@@ -60,6 +65,42 @@ spec =
           atomically (putTMVar pinged ())
           result <- atomically $ readTMVar exitResult
           result `shouldBe` ExitClosedByUser
+        it "refreshes renewable TLS configuration after client reset" $ \(Endpoints natsHost natsPort) -> do
+          sourceCalls <- newIORef (0 :: Int)
+          let tlsSource = do
+                atomicModifyIORef' sourceCalls $ \calls -> (calls + 1, ())
+                pure . Right $
+                  TLSConfig
+                    { tlsClientCertificate = Just (clientCert, clientKey)
+                    , tlsRootCertificates = [tlsRoot]
+                    , tlsServerName = Just natsHost
+                    , tlsInsecure = False
+                    }
+              clientOptions =
+                [ withConnectName "auth-tls-source-reset"
+                , withTLSConfigSource tlsSource
+                , withConnectionAttempts 2
+                ]
+                ++ loggerOptions
+          client <- newTestClient [(natsHost, natsPort)] clientOptions
+          (do
+              reset client []
+              ping client [] `shouldReturn` Right ()
+              readIORef sourceCalls `shouldReturn` 2)
+            `finally` close client []
+        it "uses static TLS configuration after a source option" $ \(Endpoints natsHost natsPort) -> do
+          let unavailableSource = pure (Left TLSConfigSourceUnavailable)
+              clientOptions =
+                [ withConnectName "auth-tls-static-after-source"
+                , withTLSConfigSource unavailableSource
+                , withTLSCert (clientCert, clientKey)
+                , withTLSRootCA tlsRoot
+                , withConnectionAttempts 1
+                ]
+                ++ loggerOptions
+          client <- newTestClient [(natsHost, natsPort)] clientOptions
+          ping client [] `shouldReturn` Right ()
+          close client []
         it "receives large messages intact across partial tls reads" $ \(Endpoints natsHost natsPort) -> do
           received <- newEmptyTMVarIO
           let body = BS.replicate (128 * 1024) 120

--- a/test/PublicAPI/Main.hs
+++ b/test/PublicAPI/Main.hs
@@ -35,6 +35,12 @@ configuredServer =
     Left err       -> error (show err)
     Right endpoint -> endpoint
 
+tlsSource :: Client.TLSConfigSource
+tlsSource = pure (Left Client.TLSConfigSourceUnavailable)
+
+tlsSourceOption :: Client.ConfigOption
+tlsSourceOption = Client.withTLSConfigSource tlsSource
+
 serverBuilders
   :: ( Either Client.ServerConfigError Client.Server
      , Either Client.ServerConfigError Client.Server
@@ -266,4 +272,5 @@ main =
     `seq` jetStreamOperations
     `seq` messageOperations
     `seq` inspectJetStreamApiError
+    `seq` tlsSourceOption
     `seq` pure ()

--- a/test/Unit/ConnectionSpec.hs
+++ b/test/Unit/ConnectionSpec.hs
@@ -11,9 +11,10 @@ import           Control.Exception         (finally, throwIO)
 import           Control.Monad             (replicateM_, void, when)
 import qualified Data.ByteString           as BS
 import qualified Data.ByteString.Lazy      as LBS
+import           Data.IORef                (newIORef, readIORef, writeIORef)
 import           Engine                    (runEngine)
 import           Handshake.Nats
-    ( HandshakeError (HandshakeAuthError, HandshakeProtocolError, HandshakeTLSError)
+    ( HandshakeError (HandshakeAuthError, HandshakeProtocolError, HandshakeTLSConfigSourceError, HandshakeTLSError)
     , performHandshake
     )
 import           Lib.Logger
@@ -103,7 +104,12 @@ import           Types.Info                (Info (..))
 import           Types.Ping                (Ping (Ping))
 import           Types.Pong                (Pong (Pong))
 import qualified Types.Pub                 as Pub
-import           Types.TLS                 (TLSConfig (..), defaultTLSConfig)
+import           Types.TLS
+    ( TLSConfig (..)
+    , TLSConfigSourceFailure (..)
+    , defaultTLSConfig
+    , readTLSConfigSource
+    )
 
 spec :: Spec
 spec = do
@@ -175,6 +181,14 @@ spec = do
       show config `shouldNotContain` "private-key"
       show config `shouldNotContain` "private-root"
       show config `shouldContain` "tlsRootCertificates = 1 configured"
+
+    it "rejects incomplete renewable TLS snapshots" $ do
+      readTLSConfigSource (pure (Right defaultTLSConfig))
+        `shouldReturn` Left TLSConfigSourceIncomplete
+
+    it "redacts renewable TLS source exceptions" $ do
+      readTLSConfigSource (throwIO (userError "private certificate path"))
+        `shouldReturn` Left TLSConfigSourceUnavailable
 
     it "fills each TLS backend receive across partial socket reads" $ do
       chunks <- newMVar ["ab", "c", "de"]
@@ -993,6 +1007,24 @@ spec = do
         Left (HandshakeTLSError _) -> pure ()
         other -> expectationFailure ("expected TLS error, got: " ++ show other)
 
+    it "reads renewable TLS configuration before each TLS handshake" $ do
+      sourceCalls <- newIORef (0 :: Int)
+      state <- newTestStateWithConfig $ \cfg ->
+        cfg
+          { tlsConfigSource = Just $ do
+              writeIORef sourceCalls 1
+              pure (Left TLSConfigSourceUnavailable)
+          }
+      conn <- newConn connectionApi
+      writes <- newTVarIO []
+      transport <- newScriptedTransport [tlsInfoFrame] writes
+      pointTransport conn transport
+
+      result <- performHandshake connectionApi Attoparsec.parserApi state auth conn "127.0.0.1"
+
+      result `shouldBe` Left (HandshakeTLSConfigSourceError TLSConfigSourceUnavailable)
+      readIORef sourceCalls `shouldReturn` 1
+
 newTestState = do
   newTestStateWithConfig id
 
@@ -1033,6 +1065,7 @@ testConfig logger =
     , connectConfig = testConnect
     , loggerConfig = logger
     , tlsConfig = Nothing
+    , tlsConfigSource = Nothing
     , serverErrorHandler = const (pure ())
     , connectionEventHandler = const (pure ())
     , exitAction = const (pure ())
@@ -1136,6 +1169,10 @@ oversizedHandshakeChunks = replicate 17 (BS.replicate 4096 73)
 infoFrame :: BS.ByteString
 infoFrame =
   "INFO {\"server_id\":\"srv\",\"version\":\"1.0.0\",\"go\":\"go1\",\"host\":\"127.0.0.1\",\"port\":4222,\"max_payload\":1024,\"proto\":1}\r\n"
+
+tlsInfoFrame :: BS.ByteString
+tlsInfoFrame =
+  "INFO {\"server_id\":\"srv\",\"version\":\"1.0.0\",\"go\":\"go1\",\"host\":\"127.0.0.1\",\"port\":4222,\"max_payload\":1024,\"proto\":1,\"tls_available\":true}\r\n"
 
 newScriptedTransport :: [BS.ByteString] -> TVar [BS.ByteString] -> IO Transport
 newScriptedTransport chunks writes = do


### PR DESCRIPTION
## Summary
- add a complete mutual-TLS snapshot source read for every TLS handshake
- keep static TLS options, with last TLS option winning
- redact source failures and expose typed connection failures
- cover reset refresh and static compatibility against NATS

## Verification
- nix flake check
- cabal integration suite
- cabal system suite