### PR TITLE
feat: drain core subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ reply <- Nats.request client "service.echo" "hello" [Nats.withRequestTimeout 2]
 reply, and cleans up the subscription on replies, timeouts, connection closure,
 and exceptions.
 
+### Graceful subscription drain
+
+`drainSubscriptions` is for service shutdown. It sends `UNSUB` for the supplied
+subscriptions and waits for the server acknowledgement before removing local
+callbacks. Messages accepted before that acknowledgement run to completion;
+later messages are not delivered to the draining service.
+
+```haskell
+result <- Nats.drainSubscriptions client [handle] [Nats.withFlushTimeout 5]
+```
+
+It is intentionally separate from `unsubscribe`, which removes the local
+callback immediately and is appropriate when in-flight work need not finish.
+
 ### Authentication and TLS
 
 Static authentication is available through `withAuthToken`, `withUserPass`,

--- a/client/API.hs
+++ b/client/API.hs
@@ -27,6 +27,7 @@ module API
   , subscribeOnce
   , request
   , unsubscribe
+  , drainSubscriptions
   , newInbox
   , ping
   , flush
@@ -68,6 +69,7 @@ import           Client.API
     , UnsubscribeOption
     , close
     , connectionState
+    , drainSubscriptions
     , flush
     , headers
     , newInbox

--- a/client/Client/Implementation.hs
+++ b/client/Client/Implementation.hs
@@ -100,6 +100,7 @@ import           Client.API
     , ResetConfig (..)
     , Subscription (..)
     , UnsubscribeConfig (..)
+    , subscriptionSid
     )
 import           Control.Concurrent
     ( forkIOWithUnmask
@@ -209,12 +210,14 @@ import           Subscription.Store
     ( SubscriptionStore
     , awaitCallbackDrain
     , awaitNoTrackedExpiries
+    , awaitSubscriptionDrain
     , closeStore
     , enqueueControl
     , hasTrackedExpiries
     , newSubscriptionStore
     , register
     , registerWithDispatchHooks
+    , retire
     , startExpiryWorker
     , startWorkers
     , unregister
@@ -417,6 +420,22 @@ newClient servers configOptions = mask $ \restoreInitialWait -> do
         , unsubscribe = \subscription options ->
             case applyCallOptions options UnsubscribeConfig of
               UnsubscribeConfig -> unsubscribeClient clientState store subscription
+        , drainSubscriptions = \subscriptions options ->
+            case applyCallOptions options defaultFlushConfig of
+              FlushConfig ->
+                drainSubscriptionsClient
+                  connectionApi
+                  clientState
+                  store
+                  subscriptions
+                  defaultRoundTripTimeout
+              FlushConfigTimeout timeoutSeconds ->
+                drainSubscriptionsClient
+                  connectionApi
+                  clientState
+                  store
+                  subscriptions
+                  timeoutSeconds
         , newInbox = nextInbox clientState
         , ping = \options ->
             case applyCallOptions options defaultPingConfig of
@@ -1116,6 +1135,75 @@ unsubscribeClient client store (Subscription sid) =
       Right UnsubscribeReset     -> do
         interruptConnection connectionApi client
         pure (Right ())
+
+-- | A drain keeps callbacks registered until NATS confirms every preceding
+-- @UNSUB@. The PONG is an ordering fence: all messages the server could have
+-- delivered before the unsubscribe are now queued locally, so waiting on their
+-- subscriptions cannot race a reply against connection close.
+drainSubscriptionsClient
+  :: ConnectionAPI
+  -> ClientState
+  -> SubscriptionStore
+  -> [Subscription]
+  -> NominalDiffTime
+  -> IO (Either NatsError ())
+drainSubscriptionsClient _ _ _ [] _ =
+  pure (Right ())
+drainSubscriptionsClient connectionApi' client store subscriptions timeoutSeconds = do
+  fenced <- awaitFence
+  case fenced of
+    Left err ->
+      pure (Left err)
+    Right () -> do
+      atomically $
+        mapM_ (awaitSubscriptionDrain store . subscriptionSid) subscriptions
+      mapM_ (unregister store . subscriptionSid) subscriptions
+      pure (Right ())
+  where
+    commands =
+      QueueConnectionScoped . QueueBatch $
+        map unsubscribeCommand subscriptions
+
+    unsubscribeCommand (Subscription sid) =
+      QueueItem Unsub.Unsub { Unsub.sid = sid, Unsub.maxMsg = Nothing }
+
+    awaitFence = do
+      result <- withSubscriptionGate client $ do
+        status <- readStatus client
+        case status of
+          ConnectionConnected ->
+            Just <$> fenceConnected
+          ConnectionConnecting ->
+            pure Nothing
+          ConnectionReconnecting ->
+            pure Nothing
+          ConnectionClosing reason ->
+            pure (Just (Left (NatsConnectionClosed reason)))
+          ConnectionClosed reason ->
+            pure (Just (Left (NatsConnectionClosed reason)))
+      case result of
+        Just value ->
+          pure value
+        Nothing -> do
+          connected <- runningResult client
+          case connected of
+            Left err -> pure (Left err)
+            Right () -> awaitFence
+
+    fenceConnected = do
+      enqueueResult <- enqueue client commands
+      case enqueueResult of
+        Right () -> do
+          flushed <- flushClient connectionApi' client timeoutSeconds
+          case flushed of
+            Left err ->
+              pure (Left err)
+            Right () -> do
+              mapM_ (retire store . subscriptionSid) subscriptions
+              pure (Right ())
+        Left _ -> do
+          status <- readStatus client
+          pure (Left (closedError status))
 
 cleanupResumableSubscription
   :: ClientState

--- a/internal/Client/API.hs
+++ b/internal/Client/API.hs
@@ -62,6 +62,8 @@ data Client = Client
                   -- ^ Publish a request and wait for one response.
                 , unsubscribe :: Subscription -> [UnsubscribeOption] -> IO (Either NatsError ())
                   -- ^ Unsubscribe a subscription created by this client.
+                , drainSubscriptions :: [Subscription] -> [FlushOption] -> IO (Either NatsError ())
+                  -- ^ Stop server delivery, then wait for callbacks already accepted.
                 , newInbox :: IO Subject
                   -- ^ Create a unique inbox subject for replies.
                 , ping :: [PingOption] -> IO (Either NatsError ())

--- a/internal/Policy/Subscription/Store.hs
+++ b/internal/Policy/Subscription/Store.hs
@@ -6,11 +6,13 @@ module Subscription.Store
   , registerWithAcceptance
   , registerWithDispatchHooks
   , unregister
+  , retire
   , dispatchMessage
   , active
   , closeStore
   , startWorkers
   , awaitCallbackDrain
+  , awaitSubscriptionDrain
   , enqueueControl
   , startExpiryWorker
   , awaitNoTrackedExpiries
@@ -53,14 +55,15 @@ data DispatchResult = DispatchMissing
   deriving (Eq, Show)
 
 data SubscriptionStore = SubscriptionStore
-                           { storeState           :: TVar SubscriptionState
-                           , storeCallbackQueue   :: TQueue (IO ())
-                           , storeCallbackPending :: TVar Int
-                           , storeDeliveryPending :: TVar Int
-                           , storeDeliveryBytes   :: TVar Int
-                           , storeSlowConsumer    :: TVar Bool
-                           , storePendingLimits   :: PendingLimits
-                           , storeSlowAction      :: IO ()
+                           { storeState               :: TVar SubscriptionState
+                           , storeCallbackQueue       :: TQueue (IO ())
+                           , storeCallbackPending     :: TVar Int
+                           , storeSubscriptionPending :: TVar (Map.Map SID Int)
+                           , storeDeliveryPending     :: TVar Int
+                           , storeDeliveryBytes       :: TVar Int
+                           , storeSlowConsumer        :: TVar Bool
+                           , storePendingLimits       :: PendingLimits
+                           , storeSlowAction          :: IO ()
                            }
 
 newSubscriptionStore :: PendingLimits -> IO () -> IO SubscriptionStore
@@ -69,6 +72,7 @@ newSubscriptionStore limits slowAction =
     <$> newTVarIO emptySubscriptionState
     <*> newTQueueIO
     <*> newTVarIO 0
+    <*> newTVarIO Map.empty
     <*> newTVarIO 0
     <*> newTVarIO 0
     <*> newTVarIO False
@@ -138,6 +142,13 @@ unregister store sid =
   atomically $
     modifyTVar' (storeState store) (removeSubscriptionLocal sid)
 
+-- | Stop a subscription being resumed while preserving callbacks that the
+-- server accepted before its unsubscribe fence.
+retire :: SubscriptionStore -> SID -> IO ()
+retire store sid =
+  atomically $
+    modifyTVar' (storeState store) (retireSubscriptionLocal sid)
+
 dispatchMessage :: SubscriptionStore -> M.Msg -> IO DispatchResult
 dispatchMessage store msg = do
   (result, onDropped) <- atomically $ do
@@ -159,7 +170,7 @@ dispatchMessage store msg = do
         writeTVar (storeState store) nextState
         if canQueue
           then do
-            enqueueDeliverySTM store messageBytes (deliverMessage callback (Just msg))
+            enqueueDeliverySTM store sid messageBytes (deliverMessage callback (Just msg))
             pure (DispatchQueued, pure ())
           else do
             rejectMessage callback
@@ -186,6 +197,11 @@ startWorkers concurrency store =
 awaitCallbackDrain :: SubscriptionStore -> STM ()
 awaitCallbackDrain store = do
   pending <- readTVar (storeCallbackPending store)
+  check (pending == 0)
+
+awaitSubscriptionDrain :: SubscriptionStore -> SID -> STM ()
+awaitSubscriptionDrain store sid = do
+  pending <- Map.findWithDefault 0 sid <$> readTVar (storeSubscriptionPending store)
   check (pending == 0)
 
 enqueueControl :: SubscriptionStore -> IO () -> IO ()
@@ -219,18 +235,22 @@ enqueueControlCallbackSTM store action = do
         action `finally` atomically (modifyTVar' (storeCallbackPending store) (subtract 1))
   writeTQueue (storeCallbackQueue store) wrapped
 
-enqueueDeliverySTM :: SubscriptionStore -> Int -> IO () -> STM ()
-enqueueDeliverySTM store messageBytes action = do
+enqueueDeliverySTM :: SubscriptionStore -> SID -> Int -> IO () -> STM ()
+enqueueDeliverySTM store sid messageBytes action = do
   modifyTVar' (storeCallbackPending store) (+1)
+  modifyTVar'
+    (storeSubscriptionPending store)
+    (Map.insertWith (+) sid 1)
   modifyTVar' (storeDeliveryPending store) (+1)
   modifyTVar' (storeDeliveryBytes store) (+ messageBytes)
   let wrapped =
-        action `finally` atomically (releaseDeliverySTM store messageBytes)
+        action `finally` atomically (releaseDeliverySTM store sid messageBytes)
   writeTQueue (storeCallbackQueue store) wrapped
 
-releaseDeliverySTM :: SubscriptionStore -> Int -> STM ()
-releaseDeliverySTM store messageBytes = do
+releaseDeliverySTM :: SubscriptionStore -> SID -> Int -> STM ()
+releaseDeliverySTM store sid messageBytes = do
   modifyTVar' (storeCallbackPending store) (subtract 1)
+  modifyTVar' (storeSubscriptionPending store) (Map.update decrement sid)
   modifyTVar' (storeDeliveryPending store) (subtract 1)
   modifyTVar' (storeDeliveryBytes store) (subtract messageBytes)
   pendingMessages <- readTVar (storeDeliveryPending store)
@@ -241,6 +261,9 @@ releaseDeliverySTM store messageBytes = do
           && pendingBytes <= pendingByteLimit limits `div` 2
   when belowLowWater $
     writeTVar (storeSlowConsumer store) False
+  where
+    decrement 1     = Nothing
+    decrement count = Just (count - 1)
 
 hasDeliveryCapacity :: SubscriptionStore -> Int -> STM Bool
 hasDeliveryCapacity store messageBytes = do
@@ -269,9 +292,13 @@ trackSubscriptionExpiry sid expiry state =
 
 removeSubscriptionLocal :: SID -> SubscriptionState -> SubscriptionState
 removeSubscriptionLocal sid state =
+  (retireSubscriptionLocal sid state)
+    { subscriptionCallbacks = Map.delete sid (subscriptionCallbacks state) }
+
+retireSubscriptionLocal :: SID -> SubscriptionState -> SubscriptionState
+retireSubscriptionLocal sid state =
   state
-    { subscriptionCallbacks = Map.delete sid (subscriptionCallbacks state)
-    , subscriptionTrackedExpiries = Map.delete sid (subscriptionTrackedExpiries state)
+    { subscriptionTrackedExpiries = Map.delete sid (subscriptionTrackedExpiries state)
     , subscriptionMeta = Map.delete sid (subscriptionMeta state)
     }
 

--- a/natskell.cabal
+++ b/natskell.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   natskell
-version:                1.4.0.0
+version:                1.5.0.0
 synopsis:               A NATS client library written in Haskell
 tested-with:
   GHC ==8.8,

--- a/system-tests/test/System/ClientCloseSpec.hs
+++ b/system-tests/test/System/ClientCloseSpec.hs
@@ -7,7 +7,12 @@ import           Client
 import           Control.Concurrent
 import           Control.Concurrent.STM
 import           Control.Exception      (finally)
-import           Control.Monad          (void)
+import           Control.Monad          (void, when)
+import           Data.IORef
+    ( atomicModifyIORef'
+    , newIORef
+    , readIORef
+    )
 import           System.Timeout
 import           Test.Hspec
 import           TestSupport
@@ -70,4 +75,44 @@ spec = do
         finished `shouldBe` Just ()
         result <- atomically $ readTMVar exitResult
         result `shouldBe` ExitClosedByUser)
+      `finally` cleanup
+  clientSystemTest "344ff959-8ef6-469a-beb1-8dee4e06a7dc" "drain fences future deliveries and waits for accepted callbacks" $ \loggerOptions (Endpoints natsHost natsPort) -> do
+    let topic = "DRAIN.FENCE"
+    callbackStarted <- newEmptyMVar
+    releaseCallback <- newEmptyMVar
+    callbackCount <- newIORef (0 :: Int)
+    drainReturned <- newEmptyMVar
+    subscriber <- newTestClient [(natsHost, natsPort)] $
+      withConnectName "drain-fence-subscriber"
+        : loggerOptions
+    publisher <- newTestClient [(natsHost, natsPort)] $
+      withConnectName "drain-fence-publisher"
+        : loggerOptions
+    let cleanup = do
+          _ <- tryPutMVar releaseCallback ()
+          close subscriber []
+          close publisher []
+    (do
+        Right subscription <- subscribe subscriber topic [] $ \_ -> do
+          invocation <- atomicModifyIORef' callbackCount $ \count ->
+            let next = count + 1
+            in (next, next)
+          when (invocation == 1) $ do
+            putMVar callbackStarted ()
+            takeMVar releaseCallback
+        flush subscriber []
+        void (publish publisher topic "accepted-before-drain" [])
+        flush publisher []
+        timeout (5 * 1000000) (takeMVar callbackStarted) `shouldReturn` Just ()
+        _ <- forkIO $
+          drainSubscriptions subscriber [subscription] [withFlushTimeout 5]
+            >>= putMVar drainReturned
+        timeout 300000 (takeMVar drainReturned) `shouldReturn` Nothing
+        putMVar releaseCallback ()
+        timeout (5 * 1000000) (takeMVar drainReturned)
+          `shouldReturn` Just (Right ())
+        void (publish publisher topic "after-drain" [])
+        flush publisher []
+        threadDelay 300000
+        readIORef callbackCount `shouldReturn` 1)
       `finally` cleanup

--- a/test/Integration/ClientSpec.hs
+++ b/test/Integration/ClientSpec.hs
@@ -474,6 +474,33 @@ spec = do
 
         timeout 500000 (takeMVar resultVar)
           `shouldReturn` Just (Left NatsRequestTimedOut)
+      it "drains deliveries accepted before the unsubscribe fence" $ \(serv, client, _, _) -> do
+        callbackStarted <- newEmptyMVar
+        releaseCallback <- newEmptyMVar
+        drained <- newEmptyMVar
+        Right subscription <-
+          subscribe client "DRAIN.FENCE" [] $ \_ -> do
+            putMVar callbackStarted ()
+            takeMVar releaseCallback
+        let sid = subscriptionSid subscription
+            unsubscribeCommand = BS.concat ["UNSUB ", sid, "\r\n"]
+        expectClientCommand serv (BS.concat ["SUB DRAIN.FENCE ", sid, "\r\n"])
+        void . forkIO $
+          drainSubscriptions client [subscription] [withFlushTimeout 1]
+            >>= putMVar drained
+        fence <-
+          expectClientBytes
+            serv
+            (\bytes -> BS.isInfixOf unsubscribeCommand bytes && BS.isInfixOf "PING\r\n" bytes)
+            "client did not send unsubscribe fence"
+        unless (appearsBefore unsubscribeCommand "PING\r\n" fence) $
+          expectationFailure "drain PING was sent before UNSUB"
+        sendAll serv (msgFrame "DRAIN.FENCE" sid "accepted-before-fence" <> "PONG\r\n")
+        expectMVar "accepted callback did not run" callbackStarted
+        timeout 200000 (takeMVar drained) `shouldReturn` Nothing
+        putMVar releaseCallback ()
+        expectMVar "drain did not await callback completion" drained
+          `shouldReturn` Right ()
       it "reports the terminal close reason to a pending ping" $ \(serv, client, _, _) -> do
         resultVar <- newEmptyMVar
         void . forkIO $ ping client [withPingTimeout 5] >>= putMVar resultVar

--- a/test/PublicAPI/Main.hs
+++ b/test/PublicAPI/Main.hs
@@ -63,7 +63,7 @@ coreOperations client = do
   case subscription of
     Left _       -> pure ()
     Right handle -> do
-      _ <- Nats.unsubscribe client handle []
+      _ <- Nats.drainSubscriptions client [handle] [Nats.withFlushTimeout 1]
       pure ()
   _ <- Nats.request
     client

--- a/test/Unit/JetStream/MessageSpec.hs
+++ b/test/Unit/JetStream/MessageSpec.hs
@@ -311,6 +311,7 @@ fakeClient publishCalls unsubscribeCalls callbackRef =
     , Nats.unsubscribe = \(Nats.Subscription sid) _ -> do
         modifyIORef' unsubscribeCalls (++ [sid])
         pure (Right ())
+    , Nats.drainSubscriptions = \_ _ -> pure (Right ())
     , Nats.newInbox = pure "_INBOX.batch"
     , Nats.ping = \_ -> pure (Right ())
     , Nats.flush = \_ -> pure (Right ())
@@ -380,6 +381,7 @@ persistentPullFakeClient publishCalls subscribeCalls unsubscribeCalls callbackRe
     , Nats.unsubscribe = \(Nats.Subscription sid) _ -> do
         modifyIORef' unsubscribeCalls (++ [sid])
         pure (Right ())
+    , Nats.drainSubscriptions = \_ _ -> pure (Right ())
     , Nats.newInbox = pure "_INBOX.persistent"
     , Nats.ping = \_ -> pure (Right ())
     , Nats.flush = \_ -> pure (Right ())
@@ -405,6 +407,7 @@ silentFakeClient publishCalls unsubscribeCalls =
     , Nats.unsubscribe = \(Nats.Subscription sid) _ -> do
         modifyIORef' unsubscribeCalls (++ [sid])
         pure (Right ())
+    , Nats.drainSubscriptions = \_ _ -> pure (Right ())
     , Nats.newInbox = pure "_INBOX.timeout"
     , Nats.ping = \_ -> pure (Right ())
     , Nats.flush = \_ -> pure (Right ())
@@ -448,6 +451,7 @@ ackFakeClient publishCalls requestCalls response =
         modifyIORef' requestCalls (++ [(subject, body)])
         pure response
     , Nats.unsubscribe = \_ _ -> pure (Right ())
+    , Nats.drainSubscriptions = \_ _ -> pure (Right ())
     , Nats.newInbox = pure "_INBOX.ack"
     , Nats.ping = \_ -> pure (Right ())
     , Nats.flush = \_ -> pure (Right ())

--- a/test/Unit/JetStream/ProtocolSpec.hs
+++ b/test/Unit/JetStream/ProtocolSpec.hs
@@ -113,6 +113,7 @@ fakeClient =
     , Nats.subscribeOnce = \_ _ _ -> pure (Right (Nats.Subscription "0"))
     , Nats.request = \_ _ _ -> pure (Left Nats.NatsRequestTimedOut)
     , Nats.unsubscribe = \_ _ -> pure (Right ())
+    , Nats.drainSubscriptions = \_ _ -> pure (Right ())
     , Nats.newInbox = pure "_INBOX.TEST"
     , Nats.ping = \_ -> pure (Right ())
     , Nats.flush = \_ -> pure (Right ())

--- a/test/Unit/SubscriptionStoreSpec.hs
+++ b/test/Unit/SubscriptionStoreSpec.hs
@@ -9,6 +9,7 @@ import           Control.Monad
 import           Data.IORef
 import           Subscription.Store
 import           Subscription.Types
+import           System.Timeout
 import           Test.Hspec
 import           Types.Msg
 
@@ -218,6 +219,52 @@ spec = do
         `shouldReturn` DispatchDropped True
       atomically ((,) <$> readTVar accepted <*> readTVar rejected)
         `shouldReturn` (True, True)
+
+  describe "subscription drain" $ do
+    it "waits only for deliveries accepted by the selected subscription" $ do
+      firstStarted <- newEmptyMVar
+      firstRelease <- newEmptyMVar
+      secondStarted <- newEmptyMVar
+      secondRelease <- newEmptyMVar
+      stopping <- newTVarIO False
+      store <- newSubscriptionStore defaultPendingLimits (pure ())
+      register
+        store
+        "first"
+        (SubscriptionMeta "FIRST" Nothing StandardSubscription)
+        (SubscribeConfig Nothing Nothing)
+        (const (putMVar firstStarted () >> takeMVar firstRelease))
+        (pure ())
+      register
+        store
+        "second"
+        (SubscriptionMeta "SECOND" Nothing StandardSubscription)
+        (SubscribeConfig Nothing Nothing)
+        (const (putMVar secondStarted () >> takeMVar secondRelease))
+        (pure ())
+      _ <- startWorkers
+        2
+        store
+        (readTVar stopping >>= check)
+        (const (pure ()))
+
+      dispatchMessage store (message "first" "one") `shouldReturn` DispatchQueued
+      dispatchMessage store (message "second" "two") `shouldReturn` DispatchQueued
+      takeMVar firstStarted
+      takeMVar secondStarted
+      retire store "first"
+      map fst <$> active store `shouldReturn` ["second"]
+      firstPending <- timeout 100000 (atomically (awaitSubscriptionDrain store "first"))
+      firstPending `shouldBe` Nothing
+
+      putMVar firstRelease ()
+      timeout 1000000 (atomically (awaitSubscriptionDrain store "first"))
+        `shouldReturn` Just ()
+      secondPending <- timeout 100000 (atomically (awaitSubscriptionDrain store "second"))
+      secondPending `shouldBe` Nothing
+      putMVar secondRelease ()
+      atomically (awaitCallbackDrain store)
+      atomically (writeTVar stopping True)
 
 registerSubscription
   :: SubscriptionStore


### PR DESCRIPTION
Adds a core NATS subscription-drain API for graceful service shutdown. It fences NATS delivery with UNSUB plus PING/PONG, retains callbacks accepted before the fence, waits for them to complete, and then removes their local state. Includes public API, unit, mock transport, and real NATS system coverage.